### PR TITLE
provide purging support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,13 @@ confluence_parent_page
 ----------------------
 
 The root page to put the generated pages under
-   
+
+confluence_purge
+----------------
+
+Whether or not to purge legacy pages detected in the parent page.
+By default, is False.
+
 confluence_server_url
 ---------------------
 
@@ -134,6 +140,7 @@ Example `conf.py`
     confluence_publish = True
     confluence_space_name = 'TEST'
     confluence_parent_page = 'Documentation'
+    confluence_purge = False
     confluence_server_url = 'https://me.docs.com'
     confluence_server_user = 'anthony.shaw'
     confluence_server_pass = 'NotMyPassword!'

--- a/sphinxcontrib/confluencebuilder.py
+++ b/sphinxcontrib/confluencebuilder.py
@@ -35,6 +35,8 @@ def setup(app):
     app.add_config_value('confluence_space_name', None, False)
     """Name of the page within the confluence space to use as the root (if publishing)"""
     app.add_config_value('confluence_parent_page', None, False)
+    """Allow purging legacy child pages from a parent page (if publishing)."""
+    app.add_config_value('confluence_purge', None, False)
     """URL of the Confluence server to publish to"""
     app.add_config_value('confluence_server_url', None, False)
     """ Username to login to Confluence API with """


### PR DESCRIPTION
Introduces the ability to purge a detected set of legacy pages from a configured parent page. In the event a user configures the option `confluence_purge` to "True", the builder will keep track of all known descendants of the parent page. When the builder starts publishing pages, any previously tracked descendant matching the identifier of a recently uploaded page will be removed from the legacy list. During the finalization phase, if any legacy pages still remain in the list, these legacy pages will be removed.