### PR TITLE
provide header/footer support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,16 @@ confluence_server_pass
 
 Your password for confluence
 
+confluence_header_file
+----------------------
+
+The name of the file to use header data.
+
+confluence_footer_file
+----------------------
+
+The name of the file to use footer data.
+
 Example `conf.py`
 
 .. code-block:: python

--- a/sphinxcontrib/confluencebuilder.py
+++ b/sphinxcontrib/confluencebuilder.py
@@ -41,3 +41,7 @@ def setup(app):
     app.add_config_value('confluence_server_user', None, False)
     """ Password to login to Confluence API with """
     app.add_config_value('confluence_server_pass', None, False)
+    """ File to get page header information from. """
+    app.add_config_value('confluence_header_file', None, False)
+    """ File to get page footer information from. """
+    app.add_config_value('confluence_footer_file', None, False)


### PR DESCRIPTION
Introduces the ability for a user to configure a header/footer file which content can be to apply to all parsed paged. In the event a user configures the option `confluence_header_file`, the writer will attempt to read the contents of the file and inject it into each generated file before the body text. Similar with `confluence_footer_file` which will attempt to inject content after the body text.

An example case is configuring with the following header/footer configurations:

    confluence_header_file='myheader.tpl'
    confluence_footer_file='myfooter.tpl'

With a header file contents of:

```
    {panel:borderColor=#CCCCCC|bgColor=#FCFCFC}
    Page has been automatically generated.
    {panel}

```

And a footer file contents of:

```

   ----

   {expand:View History}
   {change-history}
   {expand}
```

The following rendering is an example of the above configuration:

![Uploading example-header-footer.png…]()
