### PR TITLE
writer: improve/restore reference (link) support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 
 * cleanup module's structure, versions and other minor files
 * drop 'confluence' pypi package (embedded xml-rpc support added)
+* improve hyperlink and cross-referencing arbitrary locations/documents support
 * improve proxy support
 * re-support python 3.x series
 * support anonymous publishing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,12 @@
 0.6.0 (unreleased)
 ==================
 
-* support rest api
-* support anonymous publishing
-* drop 'confluence' pypi package (embedded xml-rpc support added)
-* re-support python 3.x series
-* improve proxy support
 * cleanup module's structure, versions and other minor files
+* drop 'confluence' pypi package (embedded xml-rpc support added)
+* improve proxy support
+* re-support python 3.x series
+* support anonymous publishing
+* support rest api
 
 0.5.0 (2016-03-31)
 ==================

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -10,6 +10,7 @@
 """
 
 from .builder import ConfluenceBuilder
+from .common import ConfluenceLogger
 from sphinx.writers.text import STDINDENT
 import argparse
 
@@ -26,6 +27,8 @@ def main():
     return 0
 
 def setup(app):
+    ConfluenceLogger.initialize(app)
+
     app.require_sphinx('1.0')
     app.add_builder(ConfluenceBuilder)
     """(generic)"""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -58,6 +58,8 @@ def setup(app):
     app.add_config_value('confluence_parent_page_id_check', None, False)
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
+    """List of extension-provided macros restricted for use."""
+    app.add_config_value('confluence_restricted_macros', [], False)
     """Password to login to Confluence API with."""
     app.add_config_value('confluence_server_pass', None, False)
     """Username to login to Confluence API with."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -162,6 +162,8 @@ class ConfluenceBuilder(Builder):
                 ConfluenceDocMap.register(doc, doctitle,
                     self.config.confluence_publish_prefix)
 
+        ConfluenceDocMap.conflictCheck()
+
     def write_doc(self, docname, doctree):
         # This method is taken from TextBuilder.write_doc()
         # with minor changes to support :confval:`rst_file_transform`.

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -46,6 +46,7 @@ def relative_uri(base, to):
     return ('..' + SEP) * (len(b2)-1) + SEP.join(t2)
 
 class ConfluenceBuilder(Builder):
+    current_docname = None
     name = 'confluence'
     format = 'confluence'
     file_suffix = '.conf'
@@ -165,6 +166,8 @@ class ConfluenceBuilder(Builder):
         ConfluenceDocMap.conflictCheck()
 
     def write_doc(self, docname, doctree):
+        self.current_docname = docname
+
         # This method is taken from TextBuilder.write_doc()
         # with minor changes to support :confval:`rst_file_transform`.
         destination = StringOutput(encoding='utf-8')

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -8,19 +8,16 @@
 """
 
 from __future__ import (print_function, unicode_literals, absolute_import)
-
-import codecs
-from os import path
-
-from docutils.io import StringOutput
-
-from sphinx.builders import Builder
-from sphinx.util.osutil import ensuredir, SEP
 from .exceptions import ConfluenceConfigurationError
 from .publisher import ConfluencePublisher
 from .writer import ConfluenceWriter
-
+from docutils.io import StringOutput
+from docutils import nodes
+from sphinx.builders import Builder
+from sphinx.util.osutil import ensuredir, SEP
+from os import path
 from xmlrpc.client import Fault
+import codecs
 
 # Clone of relative_uri() sphinx.util.osutil, with bug-fixes
 # since the original code had a few errors.
@@ -153,11 +150,9 @@ class ConfluenceBuilder(Builder):
         # This method is taken from TextBuilder.write_doc()
         # with minor changes to support :confval:`rst_file_transform`.
         destination = StringOutput(encoding='utf-8')
-        # print "write(%s,%s)" % (type(doctree), type(destination))
 
         self.writer.write(doctree, destination)
         outfilename = path.join(self.outdir, self.file_transform(docname))
-        # print "write(%s,%s) -> %s" % (type(doctree), type(destination), outfilename)
         ensuredir(path.dirname(outfilename))
         try:
             f = codecs.open(outfilename, 'w', 'utf-8')

--- a/sphinxcontrib/confluencebuilder/common.py
+++ b/sphinxcontrib/confluencebuilder/common.py
@@ -30,6 +30,17 @@ class ConfluenceDocMap:
     def title(docname):
         return ConfluenceDocMap.doc2title.get(docname)
 
+    @staticmethod
+    def conflictCheck():
+        d = ConfluenceDocMap.doc2title
+        for key_a in d:
+            for key_b in d:
+                if key_a == key_b:
+                    break
+                if (d[key_a] == d[key_b]):
+                    ConfluenceLogger.warn("title conflict detected with "
+                        "'%s' and '%s'" % (key_a, key_b))
+
 class ConfluenceLogger():
     app = None
 

--- a/sphinxcontrib/confluencebuilder/common.py
+++ b/sphinxcontrib/confluencebuilder/common.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.common
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2017 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+# Maximum length for a Confluence page title.
+CONFLUENCE_MAX_TITLE_LEN = 255
+
+class ConfluenceDocMap:
+    doc2title = {}
+
+    @staticmethod
+    def register(docname, title, prefix = None):
+        if prefix:
+            title = prefix + title
+
+        if len(title) > CONFLUENCE_MAX_TITLE_LEN:
+            title = title[0:CONFLUENCE_MAX_TITLE_LEN]
+            ConfluenceLogger.warn("document title has been trimmed due to "
+                "length: %s" % docname)
+
+        ConfluenceDocMap.doc2title[docname] = title
+        ConfluenceLogger.verbose("mapping %s to title: %s" % (docname, title))
+
+    @staticmethod
+    def title(docname):
+        return ConfluenceDocMap.doc2title.get(docname)
+
+class ConfluenceLogger():
+    app = None
+
+    @staticmethod
+    def initialize(app):
+        ConfluenceLogger.app = app
+
+    @staticmethod
+    def info(*args, **kwargs):
+        if ConfluenceLogger.app:
+            ConfluenceLogger.app.info(*args, **kwargs)
+
+    @staticmethod
+    def verbose(*args, **kwargs):
+        if ConfluenceLogger.app:
+            ConfluenceLogger.app.verbose(*args, **kwargs)
+
+    @staticmethod
+    def warn(*args, **kwargs):
+        if ConfluenceLogger.app:
+            ConfluenceLogger.app.warn(*args, **kwargs)

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -9,6 +9,7 @@
 
 from __future__ import (absolute_import, print_function, unicode_literals)
 from .common import ConfluenceDocMap
+from .common import ConfluenceLogger
 from docutils import nodes, writers
 from os import path
 from sphinx import addnodes
@@ -770,7 +771,11 @@ class ConfluenceTranslator(TextTranslator):
 
     def visit_target(self, node):
         if 'refid' in node:
-            self.add_text('{anchor:' + node['refid'] + '}')
+            if 'anchor' in self.builder.config.confluence_restricted_macros:
+                ConfluenceLogger.warn("anchor macro restricted; cannot create "
+                        "link anchor (%s): %s" % (self.docname, node['refid']))
+            else:
+                self.add_text('{anchor:' + node['refid'] + '}')
 
     def depart_target(self, node):
         pass

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -7,32 +7,26 @@
     :license: BSD, see LICENSE.txt for details.
 """
 
-from __future__ import (print_function, unicode_literals, absolute_import)
-
+from __future__ import (absolute_import, print_function, unicode_literals)
+from docutils import nodes, writers
+from os import path
+from sphinx import addnodes
+from sphinx.locale import versionlabels
+from sphinx.writers.text import TextTranslator, MAXWIDTH, STDINDENT
 import codecs
 import os
 import sys
 import textwrap
 import logging
 
-from docutils import nodes, writers
-from os import path
-
-from sphinx import addnodes
-from sphinx.locale import versionlabels, _
-from sphinx.writers.text import TextTranslator, MAXWIDTH, STDINDENT
-
-
 LANG_MAP = {
     'python': 'py'
 }
-
 
 class LIST_TYPES:
     BULLET = -1
     DEFINITION = -2
     ENUMERATED = 0
-
 
 class ConfluenceWriter(writers.Writer):
     supported = ('text',)
@@ -49,7 +43,6 @@ class ConfluenceWriter(writers.Writer):
         visitor = ConfluenceTranslator(self.document, self.builder)
         self.document.walkabout(visitor)
         self.output = visitor.body
-
 
 class ConfluenceTranslator(TextTranslator):
     def __init__(self, document, builder):
@@ -192,14 +185,12 @@ class ConfluenceTranslator(TextTranslator):
         self.end_state()
 
     def visit_compound(self, node):
-        # self.log_unknown("compount", node)
         pass
 
     def depart_compound(self, node):
         pass
 
     def visit_glossary(self, node):
-        # self.log_unknown("glossary", node)
         pass
 
     def depart_glossary(self, node):
@@ -221,7 +212,6 @@ class ConfluenceTranslator(TextTranslator):
         self.states[-1].append((0, ['%s %s' % (char, text), '']))
 
     def visit_subtitle(self, node):
-        # self.log_unknown("subtitle", node)
         pass
 
     def depart_subtitle(self, node):
@@ -252,21 +242,18 @@ class ConfluenceTranslator(TextTranslator):
             self.add_text('``')
 
     def visit_desc_name(self, node):
-        # self.log_unknown("desc_name", node)
         pass
 
     def depart_desc_name(self, node):
         pass
 
     def visit_desc_addname(self, node):
-        # self.log_unknown("desc_addname", node)
         pass
 
     def depart_desc_addname(self, node):
         pass
 
     def visit_desc_type(self, node):
-        # self.log_unknown("desc_type", node)
         pass
 
     def depart_desc_type(self, node):
@@ -329,7 +316,6 @@ class ConfluenceTranslator(TextTranslator):
         self.end_state()
 
     def visit_caption(self, node):
-        # self.log_unknown("caption", node)
         pass
 
     def depart_caption(self, node):
@@ -377,10 +363,7 @@ class ConfluenceTranslator(TextTranslator):
     def visit_label(self, node):
         raise nodes.SkipNode
 
-    # TODO: option list could use some better styling
-
     def visit_option_list(self, node):
-        # self.log_unknown("option_list", node)
         pass
 
     def depart_option_list(self, node):
@@ -408,7 +391,6 @@ class ConfluenceTranslator(TextTranslator):
         pass
 
     def visit_option_string(self, node):
-        # self.log_unknown("option_string", node)
         pass
 
     def depart_option_string(self, node):
@@ -421,7 +403,6 @@ class ConfluenceTranslator(TextTranslator):
         pass
 
     def visit_description(self, node):
-        # self.log_unknown("description", node)
         pass
 
     def depart_description(self, node):
@@ -435,14 +416,12 @@ class ConfluenceTranslator(TextTranslator):
         raise nodes.SkipNode
 
     def visit_tgroup(self, node):
-        # self.log_unknown("tgroup", node)
         pass
 
     def depart_tgroup(self, node):
         pass
 
     def visit_thead(self, node):
-        # self.log_unknown("thead", node)
         pass
 
     def depart_thead(self, node):
@@ -529,8 +508,8 @@ class ConfluenceTranslator(TextTranslator):
 
     def visit_image(self, node):
         if 'alt' in node.attributes:
-            self.add_text(_('[image: %s]') % node['alt'])
-        self.add_text(_('[image]'))
+            self.add_text('[image: %s]' % node['alt'])
+        self.add_text('[image]')
         raise nodes.SkipNode
 
     def visit_transition(self, node):
@@ -618,7 +597,6 @@ class ConfluenceTranslator(TextTranslator):
         self.end_state()
 
     def visit_field_list(self, node):
-        # self.log_unknown("field_list", node)
         pass
 
     def depart_field_list(self, node):
@@ -651,14 +629,12 @@ class ConfluenceTranslator(TextTranslator):
         pass
 
     def visit_hlist(self, node):
-        # self.log_unknown("hlist", node)
         pass
 
     def depart_hlist(self, node):
         pass
 
     def visit_hlistcol(self, node):
-        # self.log_unknown("hlistcol", node)
         pass
 
     def depart_hlistcol(self, node):
@@ -755,7 +731,6 @@ class ConfluenceTranslator(TextTranslator):
         self.end_state()
 
     def visit_line(self, node):
-        # self.log_unknown("line", node)
         pass
 
     def depart_line(self, node):
@@ -809,39 +784,7 @@ class ConfluenceTranslator(TextTranslator):
         pass
 
     def visit_reference(self, node):
-        """Run upon entering a reference
 
-        Because this class inherits from the TextTranslator class,
-        regularly defined links, such as::
-
-            `Some Text`_
-
-            .. _Some Text: http://www.some_url.com
-
-        were being written as plaintext. This included internal
-        references defined in the standard rst way, such as::
-
-            `Some Reference`
-
-            .. _Some Reference:
-
-            Some Title
-            ----------
-
-        To resolve this, if ``refuri`` is not included in the node (an
-        internal, non-Sphinx-defined internal uri, the reference is
-        left unchanged (e.g. ```Some Text`_`` is written as such).
-
-        If ``internal`` is not in the node (as for an external,
-        non-Sphinx URI, the reference is rewritten as an inline link,
-        e.g. ```Some Text <http://www.some_url.com>`_``.
-
-        If ``reftitle` is in the node (as in a Sphinx-generated
-        reference), the node is converted to an inline link.
-
-        Finally, all other links are also converted to an inline link
-        format.
-        """
         if 'refuri' not in node:
             if 'name' in node:
                 self.add_text('`%s`_' % node['name'])
@@ -872,12 +815,7 @@ class ConfluenceTranslator(TextTranslator):
             raise nodes.SkipNode
 
     def depart_reference(self, node):
-        if 'refuri' not in node:
-            pass  # Don't add these anchors
-        elif 'internal' not in node:
-            pass  # Don't add external links (they are automatically added by the reST spec)
-        elif 'reftitle' in node:
-            pass
+        pass
 
     def visit_download_reference(self, node):
         self.log_unknown("download_reference", node)
@@ -912,7 +850,6 @@ class ConfluenceTranslator(TextTranslator):
             self.add_text(' (%s)' % node['explanation'])
 
     def visit_title_reference(self, node):
-        # self.log_unknown("title_reference", node)
         self.add_text('*')
 
     def depart_title_reference(self, node):
@@ -951,14 +888,12 @@ class ConfluenceTranslator(TextTranslator):
         pass
 
     def visit_generated(self, node):
-        # self.log_unknown("generated", node)
         pass
 
     def depart_generated(self, node):
         pass
 
     def visit_inline(self, node):
-        # self.log_unknown("inline", node)
         pass
 
     def depart_inline(self, node):

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -100,7 +100,7 @@ class ConfluenceTranslator(TextTranslator):
         self.states.append([])
         self.stateindent.append(indent)
 
-    def end_state(self, wrap=True, end=[''], first=None):
+    def end_state(self, end=[''], first=None):
         content = self.states.pop()
         maxindent = sum(self.stateindent)
         indent = self.stateindent.pop()
@@ -110,10 +110,7 @@ class ConfluenceTranslator(TextTranslator):
         def do_format():
             if not toformat:
                 return
-            if wrap:
-                res = self.wrap(''.join(toformat), width=MAXWIDTH-maxindent)
-            else:
-                res = ''.join(toformat).splitlines()
+            res = ''.join(toformat).splitlines()
             if end:
                 res += end
             result.append((indent, res))
@@ -351,7 +348,7 @@ class ConfluenceTranslator(TextTranslator):
             else:
                 self.add_text('%s    ' % (' '*len(lastname)))
             self.add_text(production.astext() + self.nl)
-        self.end_state(wrap=False)
+        self.end_state()
         raise nodes.SkipNode
 
     def visit_seealso(self, node):
@@ -521,7 +518,7 @@ class ConfluenceTranslator(TextTranslator):
             writerow(row, is_heading)
 
         self.table = None
-        self.end_state(wrap=False)
+        self.end_state()
 
     def visit_acks(self, node):
         self.new_state(0)
@@ -743,19 +740,19 @@ class ConfluenceTranslator(TextTranslator):
 
     def depart_literal_block(self, node):
         self.add_text('{code}')
-        self.end_state(wrap=False)
+        self.end_state()
 
     def visit_doctest_block(self, node):
         self.new_state(0)
 
     def depart_doctest_block(self, node):
-        self.end_state(wrap=False)
+        self.end_state()
 
     def visit_line_block(self, node):
         self.new_state(0)
 
     def depart_line_block(self, node):
-        self.end_state(wrap=False)
+        self.end_state()
 
     def visit_line(self, node):
         # self.log_unknown("line", node)
@@ -797,7 +794,7 @@ class ConfluenceTranslator(TextTranslator):
 
     def depart_target(self, node):
         if 'refid' in node:
-            self.end_state(wrap=False)
+            self.end_state()
 
     def visit_index(self, node):
         raise nodes.SkipNode
@@ -859,7 +856,7 @@ class ConfluenceTranslator(TextTranslator):
             # reST seems unable to parse a construct like ` ``literal`` <url>`_
             # Hence we revert to the more simple `literal <url>`_
             self.add_text('`%s <%s>`_' % (node.astext(), node['refuri']))
-            # self.end_state(wrap=False)
+            # self.end_state()
             raise nodes.SkipNode
         else:
             if '#' in node['refuri']:

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,19 +1,23 @@
-import unittest
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.test.test_builder
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2016-2017 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
 from sphinx.application import Sphinx
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 import os
-
-
-class FakeServerProxy(object):
-    def __init__(self, server):
-        self.server = server
-
+import unittest
 
 class TestConfluenceBuilder(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         srcdir = os.path.join(os.getcwd(), 'testproj')
+        cls.expected = os.path.join(srcdir, 'expected')
         builddir = os.path.join(srcdir, 'build')
         cls.outdir = os.path.join(builddir, 'out')
         doctreedir = os.path.join(builddir, 'doctree')

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -58,10 +58,9 @@ class TestConfluenceBuilder(unittest.TestCase):
             self.assertEqual(lines[0], 'h1. this is a text test\n')
             self.assertEqual(lines[2], '_emphasis_\n')
             self.assertEqual(lines[4], '*strong emphasis*\n')
-            # TODO : Find out where this is going!
-            # self.assertEqual(lines[6], '[http://website.com/]\n')
-            self.assertEqual(lines[8], '----\n')
-            self.assertEqual(lines[10], 'End of transition test\n');
+            self.assertEqual(lines[6], '[http://website.com/]\n')
+            self.assertEqual(lines[10], '----\n')
+            self.assertEqual(lines[12], 'End of transition test\n');
 
     def test_admonitions(self):
         test_path = os.path.join(self.outdir, 'admonitions.conf')

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -11,6 +11,7 @@ from sphinx.application import Sphinx
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 import os
+import difflib
 import unittest
 
 class TestConfluenceBuilder(unittest.TestCase):
@@ -93,6 +94,21 @@ class TestConfluenceBuilder(unittest.TestCase):
             self.assertEqual(lines[2], '{code:title=|theme=Default|linenumbers=false|language=py|collapse=false}\n')
             self.assertEqual(lines[4], 'import antigravity\n')
             self.assertEqual(lines[5], 'antigravity.space(){code}\n')
+
+    def test_references(self):
+        expected_path = os.path.join(self.expected, 'ref.conf')
+        test_path = os.path.join(self.outdir, 'ref.conf')
+        self.assertTrue(os.path.exists(expected_path))
+        self.assertTrue(os.path.exists(test_path))
+
+        with open(expected_path, 'r') as expected_file:
+            with open(test_path, 'r') as test_file:
+                expected_data = expected_file.readlines()
+                test_data = test_file.readlines()
+                diff = difflib.unified_diff(
+                    expected_data, test_data, lineterm='')
+                diff_data = ''.join(list(diff))
+                self.assertTrue(diff_data == '', msg=diff_data)
 
     def test_toctree(self):
         test_path = os.path.join(self.outdir, 'toctree.conf')

--- a/test/testproj/expected/ref.conf
+++ b/test/testproj/expected/ref.conf
@@ -1,0 +1,31 @@
+h1. references test
+
+[http://example.com/]
+
+[http://www.example.com/]
+
+[https://example.com/]
+
+[https://www.example.com/]
+
+[Custom Link Name|http://example.com/]
+
+This is a paragraph that contains [a link|http://example.com/].
+
+Leading text [http://example.com/] with trailing text.
+
+Leading text [Custom Link Name|http://example.com/] with trailing text.
+
+[TOCTREE]
+
+[Custom Link Name|TOCTREE]
+
+{anchor:my-reference-label}
+
+h1. sub-section
+
+Some text.
+
+It refers to the section itself, see [sub-section|#my-reference-label].
+
+Another pass [Link title|#my-reference-label].

--- a/test/testproj/ref.rst
+++ b/test/testproj/ref.rst
@@ -1,0 +1,35 @@
+references test
+---------------
+
+http://example.com/
+
+http://www.example.com/
+
+https://example.com/
+
+https://www.example.com/
+
+`Custom Link Name <http://example.com/>`_
+
+This is a paragraph that contains `a link`_.
+
+.. _a link: http://example.com/
+
+Leading text http://example.com/ with trailing text.
+
+Leading text `Custom Link Name <http://example.com/>`_ with trailing text.
+
+:doc:`toctree`
+
+:doc:`Custom Link Name <toctree>`
+
+.. _my-reference-label:
+
+sub-section
+-----------
+
+Some text.
+
+It refers to the section itself, see :ref:`my-reference-label`.
+
+Another pass :ref:`Link title <my-reference-label>`.

--- a/test/testproj/toctree.rst
+++ b/test/testproj/toctree.rst
@@ -11,4 +11,5 @@ TOCTREE
    admonitions
    tables
    list
+   ref
    text


### PR DESCRIPTION
The following commits improves/restores support for a series of reference usages in Sphinx. This change includes:

 - Improves cross-referencing arbitrary locations (anchors).
 - Improves cross-referencing documents (internal).
 - Working external links.

This also includes unit test additions/restorations and cleanup of certain files.