### PR TITLE
revert "publisher: ensure used space name is uppercase"

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -49,10 +49,6 @@ class ConfluencePublisher():
         self.use_rest = not config.confluence_disable_rest
         self.use_xmlrpc = not config.confluence_disable_xmlrpc
 
-        # REST will fail if space name is not upper case.
-        if self.space_name:
-            self.space_name = self.space_name.upper()
-
     def connect(self):
         if not self.use_rest and not self.use_xmlrpc:
             raise ConfluenceConfigurationError("""Both REST and XML-RPC """


### PR DESCRIPTION
This reverts commit 4f85cd030374b8e1bafd2bf49c0e49a598008de6.

Observed on Confluence Cloud that requests are case-sensitive to the
space of a name. A user must match the configured space name to the case
of the Confluence space name.

Signed-off-by: James Knight <james.d.knight@live.com>