### PR TITLE
fix python3 < 3.6 incompatibility in rest.py

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -47,11 +47,11 @@ class Rest:
             err += "URL: " + self.url + self.BIND_PATH + "\n"
             err += "API: " + key
             raise ConfluenceBadApiError(err)
-        if not rsp.content:
+        if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
         try:
-            json_data = json.loads(rsp.content)
+            json_data = json.loads(rsp.text)
         except ValueError:
             raise ConfluenceBadServerUrlError(self.url,
                 "REST reply did not provide valid JSON data.")
@@ -78,11 +78,11 @@ class Rest:
             err += "URL: " + self.url + self.BIND_PATH + "\n"
             err += "API: " + key
             raise ConfluenceBadApiError(err)
-        if not rsp.content:
+        if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
         try:
-            json_data = json.loads(rsp.content)
+            json_data = json.loads(rsp.text)
         except ValueError:
             raise ConfluenceBadServerUrlError(self.url,
                 "REST reply did not provide valid JSON data.")
@@ -109,11 +109,11 @@ class Rest:
             err += "URL: " + self.url + self.BIND_PATH + "\n"
             err += "API: " + key
             raise ConfluenceBadApiError(err)
-        if not rsp.content:
+        if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
         try:
-            json_data = json.loads(rsp.content)
+            json_data = json.loads(rsp.text)
         except ValueError:
             raise ConfluenceBadServerUrlError(self.url,
                 "REST reply did not provide valid JSON data.")


### PR DESCRIPTION
use rsp.text instead of rsp.content for json.loads.

Prior to python3.6 json.loads only allows type str or unicode (python2).
rsp.content is of type bytes in python3 so json.loads fails (python3.* < 3.6).
rsp.text is of type str in python3, unicode in python2, it should work.

