### PR TITLE
experimental support for confluence page hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/_build/
 # testing
 .tox/
 .test_publish_key
+
+env/*

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -86,3 +86,5 @@ def setup(app):
     """(experimental)"""
     """Support experimental indentation support."""
     app.add_config_value('confluence_experimental_indentation', True, True)
+    """Support experimental page hierarchy upload from toctree data."""
+    app.add_config_value('confluence_experimental_page_hierarchy', False, True)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -14,6 +14,7 @@ from .publisher import ConfluencePublisher
 from .writer import ConfluenceWriter
 from docutils.io import StringOutput
 from docutils import nodes
+from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.util.osutil import ensuredir, SEP
 from os import path
@@ -112,6 +113,10 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
+        if self.config.master_doc and self.config.confluence_experimental_page_hierarchy:
+            self.register_parents(self.config.master_doc)
+
+
     def get_outdated_docs(self):
         """
         Return an iterable of input files that are outdated.
@@ -150,6 +155,13 @@ class ConfluenceBuilder(Builder):
         # as it contains a small bug (which was fixed in Sphinx 1.2).
         return relative_uri(self.get_target_uri(from_),
                             self.get_target_uri(to, typ))
+
+    def register_parents(self, filename):
+        tree = self.env.get_doctree(filename)
+        for toctreenode in tree.traverse(addnodes.toctree):
+            for includefile in toctreenode['includefiles']:
+                ConfluenceDocMap.registerParent(includefile, filename)
+                self.register_parents(includefile)
 
     def prepare_writing(self, docnames):
         for doc in docnames:
@@ -223,7 +235,14 @@ class ConfluenceBuilder(Builder):
             self.warn("skipping document with no title: %s" % docname)
             return
 
-        uploaded_id = self.publisher.storePage(title, output, self.parent_id)
+        parent = ConfluenceDocMap.parent(docname)
+        parent_id = ConfluenceDocMap.id(parent)
+        if not parent_id:
+            parent_id = self.parent_id
+
+        uploaded_id = self.publisher.storePage(title, output, parent_id)
+        ConfluenceDocMap.registerID(docname, uploaded_id)
+
         if self.config.confluence_purge:
             if uploaded_id in self.legacy_pages:
                 self.legacy_pages.remove(uploaded_id)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -113,10 +113,6 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
-        if self.config.master_doc and self.config.confluence_experimental_page_hierarchy:
-            self.register_parents(self.config.master_doc)
-
-
     def get_outdated_docs(self):
         """
         Return an iterable of input files that are outdated.
@@ -164,6 +160,10 @@ class ConfluenceBuilder(Builder):
                 self.register_parents(includefile)
 
     def prepare_writing(self, docnames):
+        if self.config.master_doc:
+            if self.config.confluence_experimental_page_hierarchy:
+                self.register_parents(self.config.master_doc)
+
         for doc in docnames:
             doctree = self.env.get_doctree(doc)
 

--- a/sphinxcontrib/confluencebuilder/common.py
+++ b/sphinxcontrib/confluencebuilder/common.py
@@ -12,6 +12,8 @@ CONFLUENCE_MAX_TITLE_LEN = 255
 
 class ConfluenceDocMap:
     doc2title = {}
+    doc2id = {}
+    doc2parent = {}
     refid2target = {}
 
     @staticmethod
@@ -34,8 +36,27 @@ class ConfluenceDocMap:
         return title
 
     @staticmethod
+    def registerParent(docname, parent_docname):
+        ConfluenceDocMap.doc2parent[docname] = parent_docname
+        ConfluenceLogger.verbose("setting parent of %s to: %s" % (docname, parent_docname))
+        return docname
+
+    @staticmethod
+    def registerID(docname, conf_id):
+        ConfluenceDocMap.doc2id[docname] = conf_id
+        return docname
+
+    @staticmethod
     def target(refid):
         return ConfluenceDocMap.refid2target.get(refid)
+
+    @staticmethod
+    def parent(docname):
+        return ConfluenceDocMap.doc2parent.get(docname)
+
+    @staticmethod
+    def id(docname):
+        return ConfluenceDocMap.doc2id.get(docname)
 
     @staticmethod
     def title(docname):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -283,6 +283,7 @@ class ConfluencePublisher():
                         newPage['ancestors'] = [{'id': parent_id}]
 
                     rsp = self.rest_client.post('content', newPage)
+                    uploaded_page_id = rsp['id']
                 else:
                     page = rsp['results'][0]
                     last_version = int(page['version']['number'])


### PR DESCRIPTION
This change adds the `confluence_experimental_page_hierarchy` option. When True, the builder will scan the `master_doc` for any toctree and recursively set up parent docs. On publish, the parent of each doc in confluence will be set to it's parent in the toctree. 

Adds functionality from https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/35