### PR TITLE
Inline all documents after a max_depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/_build/
 # testing
 .tox/
 .test_publish_key
+
+env/*

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -84,5 +84,7 @@ def setup(app):
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
 
     """(experimental)"""
+    """Max sub-page depth before inlining all toctree dependancies."""
+    app.add_config_value('confluence_experimental_max_depth', None, True)
     """Support experimental indentation support."""
     app.add_config_value('confluence_experimental_indentation', True, True)

--- a/sphinxcontrib/confluencebuilder/common.py
+++ b/sphinxcontrib/confluencebuilder/common.py
@@ -13,6 +13,7 @@ CONFLUENCE_MAX_TITLE_LEN = 255
 class ConfluenceDocMap:
     doc2title = {}
     refid2target = {}
+    doc2depth = {}
 
     @staticmethod
     def registerTarget(refid, target):
@@ -34,12 +35,21 @@ class ConfluenceDocMap:
         return title
 
     @staticmethod
+    def registerDepth(docname, depth):
+        ConfluenceDocMap.doc2depth[docname] = depth
+        return depth
+
+    @staticmethod
     def target(refid):
         return ConfluenceDocMap.refid2target.get(refid)
 
     @staticmethod
     def title(docname):
         return ConfluenceDocMap.doc2title.get(docname)
+
+    @staticmethod
+    def depth(docname):
+        return ConfluenceDocMap.doc2depth.get(docname)
 
     @staticmethod
     def conflictCheck():

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -56,6 +56,7 @@ class ConfluenceTranslator(TextTranslator):
 
         # Determine document's name (if any).
         assert builder.current_docname
+        self.docnames = [builder.current_docname]
         self.docname = builder.current_docname
         if SEP in self.docname:
             self.docparent = self.docname[0:self.docname.rfind(SEP)+1]
@@ -75,6 +76,7 @@ class ConfluenceTranslator(TextTranslator):
         self.states = [[]]
         self.stateindent = [0]
         self.list_stack = []
+
         self.sectionlevel = 1
         self.table = False
         self.escape_newlines = 0
@@ -164,6 +166,15 @@ class ConfluenceTranslator(TextTranslator):
                     f.close()
             except (IOError, OSError) as err:
                 self.builder.warn("error reading file %s: %s" % (footerFile, err))
+
+    def visit_start_of_file(self, node):
+        # type: (nodes.Node) -> None
+        # only occurs in the single-file builder
+        self.docnames.append(node['docname'])
+
+    def depart_start_of_file(self, node):
+        # type: (nodes.Node) -> None
+        self.docnames.pop()
 
     def visit_highlightlang(self, node):
         raise nodes.SkipNode


### PR DESCRIPTION
In this change, if you set `confluence_experimental_max_depth`, the builder will render all toctree imports beyond the posted number inline in the page. For example `confluence_experimental_max_depth=0` will have similar behavior to the 'singlehtml' builder in sphinx proper. 

No tests in this one yet. I'll update this after we merge the the page_hierarchy one if you want to go in that direction. 