### PR TITLE
publisher: allow publish without notification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@
 * re-work generated document references/targets (reference to section names)
 * sanitize output to prevent Confluence errors for certain characters
 * support indentations markup
+* support silent page updates
 
 0.6.0 (2017-04-23)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,12 @@ identifier of the parent page, both the parent page's name and identifier must
 match before this extension will publish any content to a Confluence server.
 This serves as a sanity-check configuration for the cautious.
 
+confluence_disable_notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Explicitly disable any page update notifications (i.e. treats page updates from
+a publish request as minor updates). By default, is ``False``.
+
 confluence_disable_rest
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -52,6 +52,8 @@ def setup(app):
     app.add_config_value('confluence_disable_rest', None, False)
     """Explictly prevent any Confluence XML-RPC API callers."""
     app.add_config_value('confluence_disable_xmlrpc', None, False)
+    """Explictly prevent page notifications on update."""
+    app.add_config_value('confluence_disable_notifications', None, False)
     """Root/parent page's name to publish documents into."""
     app.add_config_value('confluence_parent_page', None, False)
     """Root/parent page's identifier to publish documents into."""


### PR DESCRIPTION
In Confluence, when a page is updated, watchers will be notified of any page changes unless the edit is flagged as minor. The following provides the ability for a publisher to flag any page updates as minor edits. By setting the configuration option `confluence_disable_notifications` to `True`, any existing page edits will be flagged as a "minor edit".

For XML-RPC publishing, page updates are now handled by the "updatePage" method (over the "storePage" method). This is to allow the publisher to provide update options along side any page content edits.