### PR TITLE
support interim pip for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# Config file for automatic testing at travis-ci.org
-# This file will be regenerated if you run travis_pypi_setup.py
-
 language: python
 python: 3.5
 
@@ -11,8 +8,8 @@ env:
   - TOXENV=py27
   - TOXENV=pylint
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox
+install:
+ - pip install --upgrade tox
 
-# command to run tests, e.g. python setup.py test
-script: tox
+script:
+ - tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,9 @@ HTMLParser
 future
 requests
 sphinx
+
+#
+# force most recent version of pip for environment
+#  see: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/45
+#
+-e git+https://github.com/pypa/pip@master#egg=pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{27,33,34,35,36}, lint, pylint
+skip_missing_interpreters = true
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
The Travis CI environment prepares a test environment with the most recent version of pip available (v9.0.1); however, using this version results in the following error #45:

    AttributeError: '_NamespacePath' object has no attribute 'sort'

Adjusting the tox requirements to forcefully update pip to the newest version for the interim. When pip v9.0.2+ is available, this commit can be reverted.