### PR TITLE
builder: do not default suppress configuration error message

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -58,7 +58,7 @@ class ConfluenceBuilder(Builder):
     master_doc_page_id = None
     publisher = ConfluencePublisher()
 
-    def init(self, suppress_conf_check=True):
+    def init(self, suppress_conf_check=False):
         if not ConfluenceConfig.validate(self.config, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 


### PR DESCRIPTION
Corrects a regression error which, by default, suppresses any helpful configuration error messages from being shown to the user. At this any, any configuration error detect simply outputs "configuration error". A suppression mechanism was added to help limit the output of a unit test when validating bad configuration states (1784761446fe0baa76cce16a0886b697abf14ba5). A builder should not suppress the configuration message by default. The argument flag in the builder's initializer is being toggled to correct this.