### PR TITLE
python 3.3.x has been obsoleted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 3.5
 env:
   - TOXENV=py35
   - TOXENV=py34
-  - TOXENV=py33
   - TOXENV=py27
   - TOXENV=pylint
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ publish them to a Confluence server.
 Requirements
 ============
 
-* Python_ 2.7 or 3.3+
+* Python_ 2.7 or 3.4+
 * Requests_
 * Sphinx_ 1.0+
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,36}, lint, pylint
+envlist = py{27,34,35,36}, lint, pylint
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python Software Foundation has published the last release of the Python 3.3 series (3.3.7). Version for this series is no longer supported as of 2017-09-29. See:

> https://www.python.org/downloads/release/python-337/

Drop references to Python 3.3.x in the README.rst file as well as remove setup/CI references.

In a related note, even Travis CI has dropped Python 3.3.x support:
```
ERROR: InterpreterNotFound: python3.3
(ex: https://travis-ci.org/tonybaloney/sphinxcontrib-confluencebuilder/jobs/315668142)
```