### PR TITLE
rfc: slew of extension improvements - "red parachute"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Atlassian Confluence Builder for Sphinx
     :alt: Documentation Status
 
 Sphinx_ extension to build Confluence Wiki markup formatted files and optionally
-publish them to a Confluence server.
+publish them to a Confluence instance.
 
 Requirements
 ============
@@ -28,7 +28,7 @@ Requirements
 
 If publishing:
 
-* Confluence_ 4.0+
+* Confluence_ Cloud or Server 4.0+
 
 Installing
 ==========

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -132,6 +132,20 @@ the master_doc_ configuration is ignored with a value of ``False``.
 
     confluence_master_homepage = False
 
+confluence_max_doc_depth
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+An integer value, if provided, to indicate the maximum depth permitted for a
+nested child page before its contents is inlined with a parent. The root of all
+pages is typically the configured master_doc_. The root page is considered to be
+at a depth of zero. By defining a value of ``0``, all child pages of the root
+document will be merged into a single document. By default, the maximum document
+depth is disabled with a value of ``None``.
+
+.. code-block:: python
+
+    confluence_max_doc_depth = 2
+
 confluence_page_hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -180,6 +180,11 @@ An example publish prefix is as follows:
 confluence_purge
 ~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    Publishing individual/subset of documents with this option may lead to
+    unexpected results.
+
 A boolean value to whether or not purge legacy pages detected in a space or
 parent page. By default, this value is set to ``False`` to indicate that no
 pages will be removed. If this configuration is set to ``True``, detected pages
@@ -191,6 +196,13 @@ elsewise, all pages in the configured space could be removed.
 .. code-block:: python
 
     confluence_purge = False
+
+While this capability is useful for updating a series of pages, it may lead to
+unexpected results when attempting to publish a single-page update. The purge
+operation will remove all pages that are not publish in the request. For
+example, if an original request publishes ten documents and purges excess
+documents, a following publish attempt with only one of the documents will purge
+the other nine pages.
 
 advanced configuration - processing
 -----------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -36,10 +36,15 @@ value is set to ``False``.
 confluence_server_pass
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The password used to authenticate with the Confluence server.
+The password value used to authenticate with the Confluence instance. If using
+Confluence cloud, it is recommended to use an API token (if supported) for the
+configured username value (see api_tokens_). If API tokens are not being used,
+the plain password for the configured username value should be used.
 
 .. code-block:: python
 
+    confluence_server_pass = 'vsUsrSZ6Z4kmrQMapSXBYkJh'
+        (or)
     confluence_server_pass = 'myawesomepassword'
 
 confluence_server_url
@@ -59,10 +64,14 @@ should be as follows:
 confluence_server_user
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The username used to authenticate with the Confluence server.
+The username value used to authenticate with the Confluence instance. If using
+Confluence cloud, this value will most likely be the account's E-mail address.
+If using Confluence server, this value will most likely be the username value.
 
 .. code-block:: python
 
+    confluence_server_user = 'myawesomeuser@example.com'
+        (or)
     confluence_server_user = 'myawesomeuser'
 
 confluence_space_name
@@ -330,5 +339,6 @@ seconds, the following can be used:
     confluence_timeout = 10
 
 .. _Requests: https://pypi.python.org/pypi/requests
+.. _api_tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
 .. _master_doc: http://www.sphinx-doc.org/en/stable/config.html#confval-master_doc
 .. _toctree: http://www.sphinx-doc.org/en/stable/markup/toctree.html#directive-toctree

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -18,4 +18,4 @@ following command:
 
 .. _Read the Docs: https://readthedocs.org/
 .. _Sphinx: http://sphinx-doc.org/
-.. _sphinx_rtd_theme:: https://github.com/rtfd/sphinx_rtd_theme#installation
+.. _sphinx_rtd_theme: https://github.com/rtfd/sphinx_rtd_theme#installation

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -58,6 +58,8 @@ def setup(app):
     app.add_config_value('confluence_disable_notifications', None, False)
     """Enablement of configuring master as space's homepage."""
     app.add_config_value('confluence_master_homepage', None, False)
+    """Enablement of the maximum document depth (before inlining)."""
+    app.add_config_value('confluence_max_doc_depth', None, False)
     """Enablement of publishing pages into a hierarchy from a master toctree."""
     app.add_config_value('confluence_page_hierarchy', None, False)
     """Root/parent page's name to publish documents into."""

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -52,6 +52,19 @@ The option 'confluence_header_file' has been provided to find a header template
 file from a relative location. Ensure the value is set to a proper file path.
 """)
 
+        if c.confluence_max_doc_depth:
+            depth = c.confluence_max_doc_depth
+            if not isinstance(depth, int) or depth < 0:
+                errState = True
+                if log:
+                    ConfluenceLogger.error(
+"""maximum document depth is not an integer value
+
+When limiting the document depth permitted for a building/publishing event, the
+defined maximum document depth must be defined as an integer value (not a float,
+string, etc.).
+""")
+
         if c.confluence_publish:
             if c.confluence_disable_rest and c.confluence_disable_xmlrpc:
                 errState = True

--- a/sphinxcontrib/confluencebuilder/translator/shared.py
+++ b/sphinxcontrib/confluencebuilder/translator/shared.py
@@ -41,6 +41,13 @@ class ConfluenceTranslator(TextTranslator):
     def depart_centered(self, node):
         pass
 
+    def visit_start_of_file(self, node):
+        # ignore managing state of inlined documents
+        pass
+
+    def depart_start_of_file(self, node):
+        pass
+
     def visit_meta(self, node):
         # always ignore meta nodes as they are html-specific
         # http://docutils.sourceforge.net/docs/ref/rst/directives.html#meta

--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -829,10 +829,7 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
                 if target:
                     anchor = '#' + target
                 else:
-                    ConfluenceLogger.warn("unable to build link to document "
-                        "due to missing target (in "
-                        "%s): %s" % (self.docname, anchor))
-                    anchor = ''
+                    anchor = '#' + anchor
             else:
                 anchor = ''
 

--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -180,10 +180,11 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
         self.end_state()
 
     def visit_compound(self, node):
-        if self.apply_hierarchy_children_macro:
-            self.add_text('{children:depth=%s}' % self.tocdepth)
-            self.add_text(self.nl)
-            raise nodes.SkipNode
+        if 'toctree-wrapper' in node['classes']:
+            if self.apply_hierarchy_children_macro:
+                self.add_text('{children:depth=%s}' % self.tocdepth)
+                self.add_text(self.nl)
+                raise nodes.SkipNode
 
     def depart_compound(self, node):
         pass

--- a/test/publish-set/expected-wiki/toctree-doc1.conf
+++ b/test/publish-set/expected-wiki/toctree-doc1.conf
@@ -1,0 +1,5 @@
+h1. tree-doc1
+
+{anchor:example-doc1-label}
+
+Go to [doc2c|tree-doc2#checkcitations].

--- a/test/publish-set/expected-wiki/toctree-doc2.conf
+++ b/test/publish-set/expected-wiki/toctree-doc2.conf
@@ -1,0 +1,23 @@
+h1. tree-doc2
+
+h2. tree-doc2a
+
+h3. hyperlink references (part a)
+
+Validate [anonymous|http://www.example.com/static/first-link.txt] hyperlink references.
+
+h2. tree-doc2b
+
+Jump to either [doc1|tree-doc1#example-doc1-label] or [doc2|tree-doc3#example-doc3-label].
+
+h2. tree-doc2c
+
+h3. check citations
+
+Validate citation support with squashed document [^CIT2001^|#cit2001].
+
+|{anchor:cit2001}CIT2001|This is an example citation.|
+
+h3. hyperlink references (part b)
+
+Validate [anonymous|http://www.example.com/static/second-link.txt] hyperlink references.

--- a/test/publish-set/expected-wiki/toctree-doc3.conf
+++ b/test/publish-set/expected-wiki/toctree-doc3.conf
@@ -1,0 +1,5 @@
+h1. tree-doc3
+
+{anchor:example-doc3-label}
+
+Go to [doc2a|tree-doc2#hyperlinkreferences(parta)].

--- a/test/publish-set/expected-wiki/toctree.conf
+++ b/test/publish-set/expected-wiki/toctree.conf
@@ -1,0 +1,5 @@
+h1. root
+
+* [tree-doc1]
+* [tree-doc2]
+* [tree-doc3]

--- a/test/publish-set/toctree-doc1.rst
+++ b/test/publish-set/toctree-doc1.rst
@@ -1,2 +1,6 @@
 tree-doc1
 ---------
+
+.. _example-doc1-label:
+
+Go to :ref:`doc2c<example-doc2c-label>`.

--- a/test/publish-set/toctree-doc2.rst
+++ b/test/publish-set/toctree-doc2.rst
@@ -5,3 +5,5 @@ tree-doc2
    :maxdepth: 2
 
    toctree-doc2a
+   toctree-doc2b
+   toctree-doc2c

--- a/test/publish-set/toctree-doc2a.rst
+++ b/test/publish-set/toctree-doc2a.rst
@@ -1,2 +1,11 @@
 tree-doc2a
 ----------
+
+.. _example-doc2a-label:
+
+hyperlink references (part a)
++++++++++++++++++++++++++++++
+
+Validate `anonymous`__ hyperlink references.
+
+__ http://www.example.com/static/first-link.txt

--- a/test/publish-set/toctree-doc2b.rst
+++ b/test/publish-set/toctree-doc2b.rst
@@ -1,0 +1,5 @@
+tree-doc2b
+----------
+
+| Jump to either :ref:`doc1<example-doc1-label>` or
+  :ref:`doc2<example-doc3-label>`.

--- a/test/publish-set/toctree-doc2c.rst
+++ b/test/publish-set/toctree-doc2c.rst
@@ -1,0 +1,18 @@
+tree-doc2c
+----------
+
+.. _example-doc2c-label:
+
+check citations
++++++++++++++++
+
+Validate citation support with squashed document [CIT2001]_.
+
+.. [CIT2001] This is an example citation.
+
+hyperlink references (part b)
++++++++++++++++++++++++++++++
+
+Validate `anonymous`__ hyperlink references.
+
+__ http://www.example.com/static/second-link.txt

--- a/test/publish-set/toctree-doc3.rst
+++ b/test/publish-set/toctree-doc3.rst
@@ -1,2 +1,6 @@
 tree-doc3
 ---------
+
+.. _example-doc3-label:
+
+Go to :ref:`doc2a<example-doc2a-label>`.

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 import difflib
 import io
 import os
+import shutil
 import sys
 import unittest
 
@@ -24,6 +25,7 @@ class TestConfluenceBuilder(unittest.TestCase):
         build_dir = os.path.join(base_dir, 'build')
         self.out_dir = os.path.join(build_dir, 'builder-out')
         doctree_dir = os.path.join(build_dir, 'builder-doctree')
+        shutil.rmtree(build_dir, ignore_errors=True)
 
         self.config = {}
         self.config['extensions'] = ['sphinxcontrib.confluencebuilder']

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -11,6 +11,8 @@ from sphinx.application import Sphinx
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
+import difflib
+import io
 import os
 import sys
 import unittest
@@ -20,12 +22,14 @@ class TestConfluenceBuilder(unittest.TestCase):
     def setUpClass(self):
         base_dir = os.path.dirname(os.path.realpath(__file__))
         src_dir = os.path.join(base_dir, 'publish-set')
+        self.expected = os.path.join(src_dir, 'expected-wiki')
         build_dir = os.path.join(base_dir, 'build')
         self.out_dir = os.path.join(build_dir, 'publish-out')
         doctree_dir = os.path.join(build_dir, 'publish-doctree')
 
         self.config = {}
         self.config['extensions'] = ['sphinxcontrib.confluencebuilder']
+        self.config['confluence_max_doc_depth'] = 1
         self.config['confluence_page_hierarchy'] = True
         self.config['confluence_parent_page'] = 'Documentation'
         self.config['confluence_publish'] = False
@@ -36,6 +40,28 @@ class TestConfluenceBuilder(unittest.TestCase):
         self.app = Sphinx(
             src_dir, None, self.out_dir, doctree_dir, 'confluence', self.config)
         self.app.build(force_all=True)
+
+    def _assertExpectedWithOutput(self, name):
+        filename = name + '.conf'
+        expected_path = os.path.join(self.expected, filename)
+        test_path = os.path.join(self.out_dir, filename)
+        self.assertTrue(os.path.exists(expected_path))
+        self.assertTrue(os.path.exists(test_path))
+
+        with io.open(expected_path, encoding='utf8') as expected_file:
+            with io.open(test_path, encoding='utf8') as test_file:
+                expected_data = expected_file.readlines()
+                test_data = test_file.readlines()
+                diff = difflib.unified_diff(
+                    expected_data, test_data, lineterm='')
+                diff_data = ''.join(list(diff))
+                self.assertTrue(diff_data == '', msg=diff_data)
+
+    def test_max_depth(self):
+        self._assertExpectedWithOutput('toctree')
+        self._assertExpectedWithOutput('toctree-doc1')
+        self._assertExpectedWithOutput('toctree-doc2')
+        self._assertExpectedWithOutput('toctree-doc3')
 
     def test_parent_registration(self):
         root_doc = ConfluenceState.parentDocname('toctree')

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.state import ConfluenceState
 import difflib
 import io
 import os
+import shutil
 import sys
 import unittest
 
@@ -26,6 +27,7 @@ class TestConfluenceBuilder(unittest.TestCase):
         build_dir = os.path.join(base_dir, 'build')
         self.out_dir = os.path.join(build_dir, 'publish-out')
         doctree_dir = os.path.join(build_dir, 'publish-doctree')
+        shutil.rmtree(build_dir, ignore_errors=True)
 
         self.config = {}
         self.config['extensions'] = ['sphinxcontrib.confluencebuilder']

--- a/test/test_publisher.py
+++ b/test/test_publisher.py
@@ -13,6 +13,7 @@ from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from subprocess import check_output
 import io
 import os
+import shutil
 import sys
 import unittest
 
@@ -37,6 +38,7 @@ class TestConfluencePublisher(unittest.TestCase):
         build_dir = os.path.join(base_dir, 'build')
         doctree_dir = os.path.join(build_dir, 'validation-doctree')
         self.out = os.path.join(build_dir, 'validation-out')
+        shutil.rmtree(build_dir, ignore_errors=True)
 
         self.config = {}
         self.config['extensions'] = ['sphinxcontrib.confluencebuilder']

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps = -r{toxinidir}/requirements_dev.txt
 
 commands = pylint \
            --errors-only \
-		   --rcfile=./.pylintrc \
            sphinxcontrib.confluencebuilder
 
 [testenv:lint]


### PR DESCRIPTION
_(marked as RFC; while one could merged this content in, additional changes are planned to be made)_

The following contains a series of improvements for the Confluence builder extension. Most notables includes:

- Support for maximum page depth (based off of comment/changes noted in #35).
- Fix CI testing with newer version of pylint.
- A series of minor changes to documentation/etc.

Please ensure 9d0dda592a9aabc10634019eb9842eccf705a8ae is examined to ensure these changes fit with the expected long term use of this plugin.