### PR TITLE
Added escaping for dashes

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -29,7 +29,8 @@ SPECIAL_VALUE_REPLACEMENTS = {
     ('{', '&#123;'),
     ('}', '&#125;'),
     ('<', '&#60;'),
-    ('>', '&#62;')
+    ('>', '&#62;'),
+    ('-', '\-'),
 }
 
 class ConfluenceWikiTranslator(ConfluenceTranslator):


### PR DESCRIPTION
Hey everyone.

I added escaping for dashes because the Confluence markup interpreter gets confused by some edge cases like this one, and it prevents uploads:

```
Call this tool with the {{--foo}} and {{--bar}} parameters.
```

The dashes act as striketrough tags in Confluence wiki markup, whereas escaped dashes are always displayed as normal dashes, so this shouldn't break anything else.