### PR TITLE
rest: output post/put json on rest api err

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -65,6 +65,7 @@ class ConfluenceBuilder(Builder):
             raise ConfluenceConfigurationError('configuration error')
 
         self.writer = ConfluenceWriter(self)
+        self.config.sphinx_verbosity = self.app.verbosity
         self.publisher.init(self.config)
 
         server_url = self.config.confluence_server_url

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -35,6 +35,7 @@ class Rest:
             self.session.auth = (
                 config.confluence_server_user,
                 config.confluence_server_pass)
+        self.verbosity = config.sphinx_verbosity
 
     def get(self, key, params):
         restUrl = self.url + self.BIND_PATH + key
@@ -76,8 +77,9 @@ class Rest:
             raise ConfluencePermissionError("REST POST")
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
-            errdata += "\n"
-            errdata += json.dumps(data, indent=2)
+            if self.verbosity > 0:
+                errdata += "\n"
+                errdata += json.dumps(data, indent=2)
             raise ConfluenceBadApiError(errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
@@ -105,8 +107,9 @@ class Rest:
             raise ConfluencePermissionError("REST PUT")
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
-            errdata += "\n"
-            errdata += json.dumps(data, indent=2)
+            if self.verbosity > 0:
+                errdata += "\n"
+                errdata += json.dumps(data, indent=2)
             raise ConfluenceBadApiError(errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -75,7 +75,10 @@ class Rest:
         if rsp.status_code == 403:
             raise ConfluencePermissionError("REST POST")
         if not rsp.ok:
-            raise ConfluenceBadApiError(self._format_error(rsp, key))
+            errdata = self._format_error(rsp, key)
+            errdata += "\n"
+            errdata += json.dumps(data, indent=2)
+            raise ConfluenceBadApiError(errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
@@ -101,7 +104,10 @@ class Rest:
         if rsp.status_code == 403:
             raise ConfluencePermissionError("REST PUT")
         if not rsp.ok:
-            raise ConfluenceBadApiError(self._format_error(rsp, key))
+            errdata = self._format_error(rsp, key)
+            errdata += "\n"
+            errdata += json.dumps(data, indent=2)
+            raise ConfluenceBadApiError(errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 


### PR DESCRIPTION
In the event that a REST API POST/PUT call fails due to a Confluence
API error state, dump the pushed JSON content to the exception message.

This is to assist in a series of development and user-reported scenarios
where content pushes return a basic exception with only a limited amount
of information to debug. Along with the content data being dumped, the
JSON block of data will also include other helpful information such as
the target key/title, page identifier and more.

Signed-off-by: James Knight <james.d.knight@live.com>