### PR TITLE
automatically generated document titles

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -275,6 +275,22 @@ get_relative_uri_ method. The default translation will be the combination of
 advanced configuration - publishing
 -----------------------------------
 
+confluence_disable_autogen_title
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to explicitly disable the automatic generation of titles for
+documents which do not have a title set. When this extension processes a set of
+documents to publish, a document needs a title value to know which Confluence
+page to create/update. In the event where a title value cannot be extracted from
+a document, a title value will be automatically generated for the document. For
+automatically generated titles, the value will always be prefixed with
+``autogen-``. For users who wish to ignore pages which have no title, this
+option can be set to ``True``. By default, this option is set to ``False``.
+
+.. code-block:: python
+
+    confluence_disable_autogen_title = True
+
 confluence_disable_rest
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -50,6 +50,8 @@ def setup(app):
     app.add_config_value('confluence_remove_title', True, False)
 
     """(publishing)"""
+    """Explictly prevent auto-generation of titles for titleless documents."""
+    app.add_config_value('confluence_disable_autogen_title', None, False)
     """Explictly prevent any Confluence REST API callers."""
     app.add_config_value('confluence_disable_rest', None, False)
     """Explictly prevent any Confluence XML-RPC API callers."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -175,20 +175,8 @@ class ConfluenceBuilder(Builder):
         for docname in docnames:
             doctree = self.env.get_doctree(docname)
 
-            # find title for document
-            doctitle = None
-            tmpnode = doctree.next_node()
-            while isinstance(tmpnode, (nodes.comment)):
-                tmpnode = tmpnode.next_node(descend=False, siblings=True)
-            if tmpnode:
-                title_element = tmpnode.next_node(nodes.title)
-                if title_element:
-                    doctitle = title_element.astext()
-
+            doctitle = self._parse_doctree_title(docname, doctree)
             if not doctitle:
-                if self.publish:
-                    ConfluenceLogger.warn("document will not be published "
-                        "since it has no title: %s" % docname)
                 continue
 
             doctitle = ConfluenceState.registerTitle(docname, doctitle,
@@ -394,3 +382,33 @@ class ConfluenceBuilder(Builder):
         if docname not in self.cache_doctrees:
             self.cache_doctrees[docname] = self._original_get_doctree(docname)
         return self.cache_doctrees[docname]
+
+    def _parse_doctree_title(self, docname, doctree):
+        """
+        parse a doctree for a raw title value
+
+        Examine a document's doctree value to find a title value from a title
+        section element. If no title is found, a title can be automatically
+        generated (if configuration permits) or a `None` value is returned.
+        """
+        doctitle = None
+
+        # find the title value from the first element's title element (if any)
+        tmpnode = doctree.next_node()
+        while isinstance(tmpnode, (nodes.comment)):
+            tmpnode = tmpnode.next_node(descend=False, siblings=True)
+        if tmpnode:
+            title_element = tmpnode.next_node(nodes.title)
+            if title_element:
+                doctitle = title_element.astext()
+
+        if not doctitle and not self.config.confluence_disable_autogen_title:
+            doctitle = "autogen-{}".format(docname)
+            if self.publish:
+                ConfluenceLogger.warn("document will be published using an "
+                    "generated title value: {}".format(docname))
+        elif self.publish:
+            ConfluenceLogger.warn("document will not be published since it has "
+                "no title: {}".format(docname))
+
+        return doctitle

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -176,16 +176,15 @@ class ConfluenceBuilder(Builder):
             doctree = self.env.get_doctree(docname)
 
             # find title for document
-            idx = doctree.first_child_matching_class(nodes.section)
-            if idx is None or idx == -1:
-                continue
+            doctitle = None
+            tmpnode = doctree.next_node()
+            while isinstance(tmpnode, (nodes.comment)):
+                tmpnode = tmpnode.next_node(descend=False, siblings=True)
+            if tmpnode:
+                title_element = tmpnode.next_node(nodes.title)
+                if title_element:
+                    doctitle = title_element.astext()
 
-            first_section = doctree[idx]
-            idx = first_section.first_child_matching_class(nodes.title)
-            if idx is None or idx == -1:
-                continue
-
-            doctitle = first_section[idx].astext()
             if not doctitle:
                 if self.publish:
                     ConfluenceLogger.warn("document will not be published "
@@ -267,16 +266,15 @@ class ConfluenceBuilder(Builder):
             return
         self.current_docname = docname
 
-        # remove title from page contents
+        # remove title from page contents (if any)
         if self.config.confluence_remove_title:
-            idx = doctree.first_child_matching_class(nodes.section)
-            if not idx == None and not idx == -1:
-                first_section = doctree[idx]
-                idx = first_section.first_child_matching_class(nodes.title)
-                if not idx == None and not idx == -1:
-                    doctitle = first_section[idx].astext()
-                    if doctitle:
-                        first_section.remove(first_section[idx])
+            tmpnode = doctree.next_node()
+            while isinstance(tmpnode, (nodes.comment)):
+                tmpnode = tmpnode.next_node(descend=False, siblings=True)
+            if tmpnode:
+                title_element = tmpnode.next_node(nodes.title)
+                if title_element:
+                    tmpnode.remove(title_element)
 
         # This method is taken from TextBuilder.write_doc()
         # with minor changes to support :confval:`rst_file_transform`.


### PR DESCRIPTION
This pull request focuses on the enhancement request made in "provide option to automatically generate a title for titleless documents" (#68). By default, documents missing titles will have a title value automatically generated. This capability can be disable by configuring the option `confluence_disable_autogen_title`. See commit be200627b628fc02e9ea0d7ad866926c71b0aeca for more specifics.