### PR TITLE
address false positive on no title warning

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -403,13 +403,14 @@ class ConfluenceBuilder(Builder):
             if title_element:
                 doctitle = title_element.astext()
 
-        if not doctitle and not self.config.confluence_disable_autogen_title:
-            doctitle = "autogen-{}".format(docname)
-            if self.publish:
-                ConfluenceLogger.warn("document will be published using an "
-                    "generated title value: {}".format(docname))
-        elif self.publish:
-            ConfluenceLogger.warn("document will not be published since it has "
-                "no title: {}".format(docname))
+        if not doctitle:
+            if not self.config.confluence_disable_autogen_title:
+                doctitle = "autogen-{}".format(docname)
+                if self.publish:
+                    ConfluenceLogger.warn("document will be published using an "
+                        "generated title value: {}".format(docname))
+            elif self.publish:
+                ConfluenceLogger.warn("document will not be published since it "
+                    "has no title: {}".format(docname))
 
         return doctitle


### PR DESCRIPTION
Recently, support for automatic title generation for documents which
have no title has been added \[1\]. This feature introduces a false
positive warning which indicates that a page has no title, even though
the document has one. This change addresses the generated warnings to
ensure that any auto-title generation and/or warning message first
requires a missing document title.

Note: this addresses a poor logging call; older versions which include
the auto-title generation feature would still properly extract and use
document titles as expected (no matter what the logs indicated).

\[1\]: be200627b628fc02e9ea0d7ad866926c71b0aeca
