### PR TITLE
limit support to supported confluence server versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements
 
 If publishing:
 
-* Confluence_ Cloud or Server 4.0+
+* Confluence_ Cloud or Server 5.9+
 
 Installing
 ==========


### PR DESCRIPTION
Bump the minimum support for Confluence Server to at least v5.9. At the
time of this commit, v5.8 and older have reached end of life \[1\]. While
support can be maintained for older versions, attempting to limit the
amount of versions that will officially go through validating testing.

\[1\]: https://confluence.atlassian.com/display/CONF58

### additional notes
This is an attempt to help limit the amount of validation support for some prospect changes I'm hoping to complete. I've been occasionally testing with older versions of Confluence servers (ex: 4.1.10, 5.6.6, etc.) but I doubt most users are using these versions.