### PR TITLE
literal markup improvements

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -251,6 +251,24 @@ combination of "``docname`` + ``confluence_file_suffix``".
 .. _get_outdated_docs: http://www.sphinx-doc.org/en/stable/extdev/builderapi.html#sphinx.builders.Builder.get_outdated_docs
 .. _write_doc: http://www.sphinx-doc.org/en/stable/extdev/builderapi.html#sphinx.builders.Builder.write_doc
 
+confluence_lang_transform
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A function to override the translation of literal block-based directive
+language values to Confluence-support code block macro language values. The
+default translation accepts `Pygments documented language types`_ to
+`Confluence-supported syntax highlight languages`_.
+
+.. code-block:: python
+
+    def my_language_translation(lang):
+        return 'default'
+
+    confluence_lang_transform = my_language_translation
+
+.. _Confluence-supported syntax highlight languages: https://confluence.atlassian.com/confcloud/code-block-macro-724765175.html
+.. _Pygments documented language types: http://pygments.org/docs/lexers/
+
 confluence_link_suffix
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -5,7 +5,7 @@
 
     Sphinx extension to output Atlassian Confluence wiki files.
 
-    :copyright: Copyright 2016-2017 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
     :license: BSD, see LICENSE.txt for details.
 """
 
@@ -100,6 +100,10 @@ def setup(app):
     app.add_config_value('confluence_adv_trace_data', False, False)
     """Do not cap sections to a maximum of six (6) levels."""
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
+
+    """(advanced - processing)"""
+    """Translation of a raw language to code block macro language."""
+    app.add_config_value('confluence_lang_transform', None, False)
 
     """(experimental)"""
     """Support experimental indentation support."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -96,6 +96,11 @@ class ConfluenceBuilder(Builder):
         else:
             self.link_transform = link_transform
 
+        if self.config.confluence_lang_transform is not None:
+            self.lang_transform = self.config.confluence_lang_transform
+        else:
+            self.lang_transform = None
+
         if self.config.confluence_publish:
             self.publish = True
             self.publisher.connect()

--- a/sphinxcontrib/confluencebuilder/std/__init__.py
+++ b/sphinxcontrib/confluencebuilder/std/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.std.__init__
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Standards (references) package for the Sphinx-contrib Atlassian Confluence
+    extension.
+
+    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.std.confluence
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2017-2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+from .sphinx import DEFAULT_HIGHLIGHT_STYLE
+
+"""
+sphinx literal to confluence language map
+
+Provides a map of Sphinx literal language values to respective and supported*
+Confluence syntax highlight language (*support can vary based on Confluence
+version). Values of the map are driven by supported languages defined by
+Confluence documentation [1][2][3]. Keys of the map are driven by short names
+defined by Pygments [4]. This is due to Sphinx's highlighting which is managed
+by Pygments [5].
+
+[1]: https://confluence.atlassian.com/display/CONF58/Code+Block+Macro
+[2]: https://confluence.atlassian.com/doc/code-block-macro-139390.html
+[3]: https://confluence.atlassian.com/confcloud/code-block-macro-724765175.html
+[4]: http://pygments.org/docs/lexers/
+[5]: http://www.sphinx-doc.org/en/stable/markup/code.html
+"""
+LITERAL2LANG_MAP = {
+    # ActionScript
+    'actionscript3': 'actionscript3',
+    'as3': 'actionscript3',
+    # AppleScript (Confluence >=6.0)
+    'applescript': 'applescript',
+    # Bash
+    'bash': 'bash',
+    'ksh': 'bash',
+    'sh': 'bash',
+    'shell': 'bash',
+    'zsh': 'bash',
+    # C#
+    'c#': 'csharp',
+    'csharp': 'csharp',
+    # C++
+    'c': 'cpp',
+    'c++': 'cpp',
+    'cpp': 'cpp',
+    # ColdFusion
+    'cfc': 'coldfusion',
+    'coldfusion': 'coldfusion',
+    # CSS
+    'css': 'css',
+    # Delphi
+    'delphi': 'delphi',
+    'pas': 'delphi',
+    'pascal': 'delphi',
+    'objectpascal': 'delphi',
+    # Diff
+    'diff': 'diff',
+    'udiff': 'diff',
+    # Erlang
+    'erlang': 'erlang',
+    # Groovy
+    'groovy': 'groovy',
+    # HTML and XML
+    'html': 'html/xml',
+    'html/xml': 'html/xml',
+    'xml': 'html/xml',
+    'xslt': 'html/xml',
+    # Java
+    'java': 'java',
+    # Java FX
+    'javafx': 'javafx',
+    # JavaScript
+    'javascript': 'javascript',
+    'js': 'javascript',
+    # Plain Text
+    'none': 'none',
+    # Perl (Confluence <=5.10)
+    'perl': 'perl',
+    'pl': 'perl',
+    # PHP (Confluence <=5.10)
+    'php': 'php',
+    'php3': 'php',
+    'php4': 'php',
+    'php5': 'php',
+    # PowerShell
+    'posh': 'powershell',
+    'powershell': 'powershell',
+    'ps1': 'powershell',
+    'psm1': 'powershell',
+    # Python
+    'py': 'python',
+    'python': 'python',
+    'sage': 'python',
+    # Ruby
+    'duby': 'ruby',
+    'rb': 'ruby',
+    'ruby': 'ruby',
+    # Scala
+    'scala': 'scala',
+    # SQL
+    'sql': 'sql',
+    # Visual Basic
+    'vb': 'vb',
+    # (special)
+    # Sphinx's default highlight language is based off a superset of 'python'.
+    # To follow Sphinx's method of highlighting, use Confluence's 'python'
+    # highlight type as the target language for the default type.
+    #
+    # [1]: http://www.sphinx-doc.org/en/stable/config.html#confval-highlight_language
+    DEFAULT_HIGHLIGHT_STYLE: 'python'
+}

--- a/sphinxcontrib/confluencebuilder/std/sphinx.py
+++ b/sphinxcontrib/confluencebuilder/std/sphinx.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.std.sphinx
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+"""
+sphinx's default highlight style
+
+[1]: http://www.sphinx-doc.org/en/stable/config.html#confval-highlight_language
+"""
+DEFAULT_HIGHLIGHT_STYLE = 'default'

--- a/sphinxcontrib/confluencebuilder/translator/shared.py
+++ b/sphinxcontrib/confluencebuilder/translator/shared.py
@@ -3,25 +3,14 @@
     sphinxcontrib.confluencebuilder.translator.shared
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    :copyright: Copyright 2016-2017 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
     :license: BSD, see LICENSE.txt for details.
 """
 
 from __future__ import (absolute_import, print_function, unicode_literals)
+from ..std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 from docutils import nodes
 from sphinx.writers.text import TextTranslator
-
-# map of sphinx literal types to confluence code types
-#
-# This isn't a complete map of support Confluence code types. Unless specified
-# here, the default translator pattern will be to directly place a literal's
-# explicit language value into a Confluence's code macro language field. This
-# map serves as a helper to translate common Sphinx language definitions to
-# explicit language types supported by Confluence.
-LITERAL2CODE_MAP = {
-    'c': 'cpp',
-    'py': 'python'
-}
 
 # supported confluence list types
 class ConflueceListType(object):
@@ -33,6 +22,11 @@ class ConfluenceTranslator(TextTranslator):
     def __init__(self, document, builder):
         TextTranslator.__init__(self, document, builder)
 
+        if self.builder.config.highlight_language:
+            self._highlight = self.builder.config.highlight_language
+        else:
+            self._highlight = DEFAULT_HIGHLIGHT_STYLE
+
     def visit_centered(self, node):
         # centered is deprecated; ignore
         # http://www.sphinx-doc.org/en/stable/markup/para.html#directive-centered
@@ -40,6 +34,12 @@ class ConfluenceTranslator(TextTranslator):
 
     def depart_centered(self, node):
         pass
+
+    def visit_highlightlang(self, node):
+        # update the translator's highlight language from the defined directive
+        # http://www.sphinx-doc.org/en/stable/markup/code.html#directive-highlight
+        self._highlight = node.get('lang', DEFAULT_HIGHLIGHT_STYLE)
+        raise nodes.SkipNode
 
     def visit_start_of_file(self, node):
         # ignore managing state of inlined documents

--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -3,7 +3,7 @@
     sphinxcontrib.confluencebuilder.translator.wiki
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    :copyright: Copyright 2016-2017 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
     :license: BSD, see LICENSE.txt for details.
 """
 
@@ -11,9 +11,10 @@ from __future__ import (absolute_import, print_function, unicode_literals)
 from ..experimental import ConfluenceExperimentalQuoteSupport
 from ..logger import ConfluenceLogger
 from ..state import ConfluenceState
+from ..std.confluence import LITERAL2LANG_MAP
+from ..std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 from .shared import ConflueceListType
 from .shared import ConfluenceTranslator
-from .shared import LITERAL2CODE_MAP
 from docutils import nodes
 from os import path
 from sphinx import addnodes
@@ -160,9 +161,6 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
             except (IOError, OSError) as err:
                 ConfluenceLogger.warn("error reading file "
                     "%s: %s" % (footerFile, err))
-
-    def visit_highlightlang(self, node):
-        raise nodes.SkipNode
 
     def visit_section(self, node):
         level = 6 if self.sectionlevel > 6 else self.sectionlevel
@@ -707,9 +705,12 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
         self.end_state()
 
     def visit_literal_block(self, node):
-        lang = node.get('language', '')
-        if lang in LITERAL2CODE_MAP.keys():
-            lang = LITERAL2CODE_MAP[lang]
+        lang = node.get('language', self._highlight)
+        if lang in LITERAL2LANG_MAP.keys():
+            lang = LITERAL2LANG_MAP[lang]
+        else:
+            ConfluenceLogger.warn('unknown code language: {0}'.format(lang))
+            lang = LITERAL2LANG_MAP[DEFAULT_HIGHLIGHT_STYLE]
 
         if node.get('linenos', False) == True:
             nums='true'
@@ -723,9 +724,6 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
         self.add_text('{code}')
         self.add_text(self.nl)
         raise nodes.SkipNode
-
-    def depart_literal_block(self, node):
-        pass
 
     def visit_doctest_block(self, node):
         self.new_state(0)

--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -706,7 +706,9 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
 
     def visit_literal_block(self, node):
         lang = node.get('language', self._highlight)
-        if lang in LITERAL2LANG_MAP.keys():
+        if self.builder.lang_transform:
+            lang = self.builder.lang_transform(lang)
+        elif lang in LITERAL2LANG_MAP.keys():
             lang = LITERAL2LANG_MAP[lang]
         else:
             ConfluenceLogger.warn('unknown code language: {0}'.format(lang))


### PR DESCRIPTION
A series of improvements related to the usage of code block languages:
- Literal block-based directives will have language values translated to Confluence-supported language values. This is to avoid macro errors with Confluence's code block macro (see also #75).
- Adds support for Sphinx's `highlight_language` configuration and `hightlight` directive. This allows custom highlighting to be applied on literal blocks (and `literalincludes`) properly.

### unit test additions postponed
A series of unit tests to help validate some of these changes have not been included in this commit. These have been designed outside the existing `test_builder` structure into a new test suite to provide more flexibility to invoke unit tests using various configuration and Sphinx application instances. I plan to submit these changes as part of another pull request in the future.