### PR TITLE
tox pip cleanup

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,3 @@
 future
 requests
 sphinx
-
-#
-# force most recent version of pip for environment
-#  see: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/45
-#
--e git+https://github.com/pypa/pip@master#egg=pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py{27,34,35,36}, lint, pylint
-skip_missing_interpreters = true
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ skip_missing_interpreters = true
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/pluralsight
 changedir=test
 commands =
     python -m test_builder


### PR DESCRIPTION
Corrects and cleans up the tox configuration/dependency file. This should finally address primary issues experienced with Travis CI with respect to `'_NamespacePath' object has no attribute 'sort'` and other import errors.

This cleanup also reverts an older commit with relaxed CI building when missing interpreters. I believe if the intent is to support specific Python interpreters, a standard build should include them all and pass to be a valid build (and nothing stops a developer environment from manually invoking individual interprets to run).