### PR TITLE
rest: handle non-json responses

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -144,5 +144,8 @@ class Rest:
         err += "RSP: " + str(rsp.status_code) + "\n"
         err += "URL: " + self.url + self.BIND_PATH + "\n"
         err += "API: " + key + "\n"
-        err += "MSG: " + rsp.json()['message']
+        try:
+            err += 'MSG: {}'.format(rsp.json()['message'])
+        except ValueError:
+            err += 'MSG: <not-or-invalid-json>'
         return err


### PR DESCRIPTION
The typical response in an error case provided a message value
containing JSON formatted data. In the case where a server returns
non-JSON data (for example, an invalid server URL), an exception will
be thrown when preparing the message to display. The following adds
exception handling and informs the user that the returned content is not
JSON-based data.

Signed-off-by: James Knight <james.d.knight@live.com>