### PR TITLE
builder: provided flexible url handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -14,6 +14,7 @@ from .exceptions import ConfluenceConfigurationError
 from .logger import ConfluenceLogger
 from .publisher import ConfluencePublisher
 from .state import ConfluenceState
+from .util import ConfluenceUtil
 from .writer import ConfluenceWriter
 from docutils.io import StringOutput
 from docutils import nodes
@@ -76,9 +77,12 @@ class ConfluenceBuilder(Builder):
         self.config.sphinx_verbosity = self.app.verbosity
         self.publisher.init(self.config)
 
-        server_url = self.config.confluence_server_url
-        if server_url and server_url.endswith('/'):
-            self.config.confluence_server_url = server_url[:-1]
+        old_url = self.config.confluence_server_url
+        new_url = ConfluenceUtil.normalizeBaseUrl(old_url)
+        if old_url != new_url:
+            ConfluenceLogger.warn('normalizing confluence url from '
+                '{} to {} '.format(old_url, new_url))
+            self.config.confluence_server_url = new_url
 
         if self.config.confluence_file_suffix is not None:
             self.file_suffix = self.config.confluence_file_suffix

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -23,6 +23,7 @@ from .exceptions import ConfluenceLegacyError
 from .exceptions import ConfluencePermissionError
 from .exceptions import ConfluenceRemoteApiDisabledError
 from .experimental import ConfluenceExperimentalQuoteSupport
+from .std.confluence import API_XMLRPC_BIND_PATH
 from .logger import ConfluenceLogger
 from .rest import Rest
 import socket
@@ -91,7 +92,7 @@ class ConfluencePublisher():
                         transport.set_timeout(self.timeout)
 
                 self.xmlrpc = xmlrpclib.ServerProxy(
-                    self.server_url + '/rpc/xmlrpc',
+                    self.server_url + API_XMLRPC_BIND_PATH,
                     transport=transport, allow_none=True)
             except IOError as ex:
                 raise ConfluenceBadServerUrlError(self.server_url, ex)

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -16,10 +16,10 @@ from .exceptions import ConfluenceBadServerUrlError
 from .exceptions import ConfluencePermissionError
 from .exceptions import ConfluenceSeraphAuthenticationFailedUrlError
 from .exceptions import ConfluenceTimeoutError
+from .std.confluence import API_REST_BIND_PATH
 
 
 class Rest:
-    BIND_PATH = "/rest/api/"
     CONFLUENCE_DEFAULT_ENCODING = 'utf-8'
 
     def __init__(self, config):
@@ -38,7 +38,7 @@ class Rest:
         self.verbosity = config.sphinx_verbosity
 
     def get(self, key, params):
-        restUrl = self.url + self.BIND_PATH + key
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key
         try:
             rsp = self.session.get(restUrl, params=params)
         except requests.exceptions.Timeout:
@@ -64,7 +64,7 @@ class Rest:
         return json_data
 
     def post(self, key, data):
-        restUrl = self.url + self.BIND_PATH + key
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key
         try:
             rsp = self.session.post(restUrl, json=data)
         except requests.exceptions.Timeout:
@@ -94,7 +94,7 @@ class Rest:
         return json_data
 
     def put(self, key, value, data):
-        restUrl = self.url + self.BIND_PATH + key + "/" + value
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + value
         try:
             rsp = self.session.put(restUrl, json=data)
         except requests.exceptions.Timeout:
@@ -124,7 +124,7 @@ class Rest:
         return json_data
 
     def delete(self, key, value):
-        restUrl = self.url + self.BIND_PATH + key + "/" + value
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + value
         try:
             rsp = self.session.delete(restUrl)
         except requests.exceptions.Timeout:
@@ -142,7 +142,7 @@ class Rest:
         err = ""
         err += "REQ: {0}\n".format(rsp.request.method)
         err += "RSP: " + str(rsp.status_code) + "\n"
-        err += "URL: " + self.url + self.BIND_PATH + "\n"
+        err += "URL: " + self.url + API_REST_BIND_PATH + "\n"
         err += "API: " + key + "\n"
         err += "MSG: " + rsp.json()['message']
         return err

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -10,6 +10,16 @@
 from .sphinx import DEFAULT_HIGHLIGHT_STYLE
 
 """
+confluence trailing bind path for rest api
+"""
+API_REST_BIND_PATH = 'rest/api'
+
+"""
+confluence trailing bind path for xml-rpc api
+"""
+API_XMLRPC_BIND_PATH = 'rpc/xmlrpc'
+
+"""
 sphinx literal to confluence language map
 
 Provides a map of Sphinx literal language values to respective and supported*

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinxcontrib.confluencebuilder.util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE for details.
+"""
+
+from .std.confluence import API_REST_BIND_PATH
+from .std.confluence import API_XMLRPC_BIND_PATH
+
+class ConfluenceUtil:
+    """
+    confluence utility helper class
+
+    This class is used to hold a series of utility methods.
+    """
+
+    @staticmethod
+    def normalizeBaseUrl(url):
+        """
+        normalize a confluence base url
+
+        A Confluence base URL refers to the URL porition excluding the target
+        API bind point. This method attempts to handle a series of user-provided
+        URL values and attempt to determine the proper base URL to use.
+        """
+        if url:
+            # removing any trailing forward slash user provided
+            if url.endswith('/'):
+                url = url[:-1]
+            # check for xml-rpc bind path; strip and return if found
+            if url.endswith(API_XMLRPC_BIND_PATH):
+                url = url[:-len(API_XMLRPC_BIND_PATH)]
+            else:
+                # check for rest bind path; strip and return if found
+                if url.endswith(API_REST_BIND_PATH):
+                    url = url[:-len(API_REST_BIND_PATH)]
+                # restore trailing forward flash
+                elif not url.endswith('/'):
+                    url += '/'
+        return url

--- a/test/unit-tests/common/test_util.py
+++ b/test/unit-tests/common/test_util.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE for details.
+"""
+
+from sphinxcontrib.confluencebuilder.util import ConfluenceUtil as UTIL
+import unittest
+
+class TestConfluenceUtil(unittest.TestCase):
+    def test_normalize_baseurl(self):
+        data = {
+'https://example.atlassian.net/wiki':             'https://example.atlassian.net/wiki/',
+'https://example.atlassian.net/wiki/':            'https://example.atlassian.net/wiki/',
+'https://example.atlassian.net/wiki/rest/api':    'https://example.atlassian.net/wiki/',
+'https://example.atlassian.net/wiki/rest/api/':   'https://example.atlassian.net/wiki/',
+'https://example.atlassian.net/wiki/rpc/xmlrpc':  'https://example.atlassian.net/wiki/',
+'https://example.atlassian.net/wiki/rpc/xmlrpc/': 'https://example.atlassian.net/wiki/',
+'https://intranet-wiki.example.com':              'https://intranet-wiki.example.com/',
+'https://intranet-wiki.example.com/':             'https://intranet-wiki.example.com/',
+'https://intranet-wiki.example.com/rest/api':     'https://intranet-wiki.example.com/',
+'https://intranet-wiki.example.com/rest/api/':    'https://intranet-wiki.example.com/',
+'https://intranet-wiki.example.com/rpc/xmlrpc':   'https://intranet-wiki.example.com/',
+'https://intranet-wiki.example.com/rpc/xmlrpc/':  'https://intranet-wiki.example.com/',
+'http://example.atlassian.net/wiki':              'http://example.atlassian.net/wiki/',
+            }
+        for key in data:
+            self.assertEqual(UTIL.normalizeBaseUrl(key), data[key])


### PR DESCRIPTION
This extension requires a user to provide the URL path of the Confluence
instances to interact with when publishing. The configuration handling
was designed to take the "base" portion of the URL and the extension
would later attached the REST or XML-RPC bind point later.

This commit provides more flexibly in the configured URL by
automatically detecting URLs, for example, with the API bind point set.
The normalizing method will remove and cleanup the final URL before its
use. In the event that this extension normalizes the URL, a warning
message will be generated to the user (to promote a proper configuration
value).