### PR TITLE
publisher,rest: cleanup rest session

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -142,7 +142,9 @@ class ConfluencePublisher():
                     raise ConfluenceBadServerUrlError(self.server_url, ex)
 
     def disconnect(self):
-        if self.use_xmlrpc and self.token:
+        if self.use_rest:
+            self.rest_client.close()
+        elif self.use_xmlrpc and self.token:
             self.xmlrpc.logout(self.token)
 
     def getBasePageId(self):

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -138,6 +138,9 @@ class Rest:
         if not rsp.ok:
             raise ConfluenceBadApiError(self._format_error(rsp, key))
 
+    def close(self):
+        self.session.close()
+
     def _format_error(self, rsp, key):
         err = ""
         err += "REQ: {0}\n".format(rsp.request.method)


### PR DESCRIPTION
When using a REST client, close the session \[1\] when cleaning up the
publish request. This ensures the session is cleaned up, as well as
removes the following warning in some installations:

    ResourceWarning: unclosed <socket.socket fd=..., family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('...', ...), raddr=('...', ...)>

\[1\]: http://docs.python-requests.org/en/master/api/#requests.Session.close

(see also #48)