### PR TITLE
wiki: support raw data pass-through

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/wiki.py
+++ b/sphinxcontrib/confluencebuilder/translator/wiki.py
@@ -1000,6 +1000,6 @@ class ConfluenceWikiTranslator(ConfluenceTranslator):
         raise nodes.SkipNode
 
     def visit_raw(self, node):
-        if 'text' in node.get('format', '').split():
-            self.body = self.body + node.astext()
+        if 'confluence' in node.get('format', '').split():
+            self.add_text(node.astext())
         raise nodes.SkipNode


### PR DESCRIPTION
Adjusts the 'raw' directive to help support pass-through content for Confluence-prepared content. Adjusts the handle format from "text" to "confluence" (for proper format type identification) and ensure text is added to the body using internal data management.