### PR TITLE
builder: correct publish order for proper hierarchy support

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -186,7 +186,7 @@ class ConfluenceBuilder(Builder):
         # add orphans (if any) to the publish list
         ordered_docnames.extend(x for x in docnames if x not in traversed)
 
-        for docname in docnames:
+        for docname in ordered_docnames:
             doctree = self.env.get_doctree(docname)
 
             doctitle = self._parse_doctree_title(docname, doctree)
@@ -195,8 +195,7 @@ class ConfluenceBuilder(Builder):
 
             doctitle = ConfluenceState.registerTitle(docname, doctitle,
                 self.config.confluence_publish_prefix)
-            if docname in ordered_docnames:
-                self.publish_docnames.append(docname)
+            self.publish_docnames.append(docname)
 
             toctrees = doctree.traverse(addnodes.toctree)
             if toctrees and toctrees[0].get('maxdepth') > 0:


### PR DESCRIPTION
When support was added for "max-depth" \[1\], the adjusted code never took
advantage of the ordered publish document list required to ensure pages
are assigned a proper parent in hierarchy mode. Adjusting the
prepare_writing stage to work off of 'ordered_docnames' instead of
'docnames'.

\[1\]: 9d0dda592a9aabc10634019eb9842eccf705a8ae