### PR TITLE
purge improvements

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -227,6 +227,23 @@ example, if an original request publishes ten documents and purges excess
 documents, a following publish attempt with only one of the documents will purge
 the other nine pages.
 
+confluence_purge_from_master
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to which indicates that any purging attempt should be done from
+the root of a published master_doc_ page (instead of a configured parent page;
+i.e. ``confluence_parent_page``). In specific publishing scenarios, a user may
+wish to publish multiple documentation sets based off a single parent/container
+page. To prevent any purging between multiple documentation sets, this option
+can be set to ``True``. When generating legacy pages to be removed, this
+extension will only attempt to populate legacy pages based off the children of
+the master_doc_ page. This option still requires ``confluence_purge`` to be set
+to ``True`` before taking effect.
+
+.. code-block:: python
+
+    confluence_purge_from_master = False
+
 advanced configuration - processing
 -----------------------------------
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -70,6 +70,8 @@ def setup(app):
     app.add_config_value('confluence_parent_page_id_check', None, False)
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
+    """Enablement of purging legacy child pages from a master page."""
+    app.add_config_value('confluence_purge_from_master', None, False)
     """Password to login to Confluence API with."""
     app.add_config_value('confluence_server_pass', None, False)
     """Username to login to Confluence API with."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -113,7 +113,8 @@ class ConfluenceBuilder(Builder):
             self.publish = True
             self.publisher.connect()
             self.parent_id = self.publisher.getBasePageId()
-            self.legacy_pages = self.publisher.getDescendents(self.parent_id)
+            self.legacy_pages = self.publisher.getDescendentsCompat(
+                self.parent_id)
         else:
             self.publish = False
             self.parent_id = None

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -112,13 +112,8 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_publish:
             self.publish = True
             self.publisher.connect()
-            self.parent_id = self.publisher.getBasePageId()
-            self.legacy_pages = self.publisher.getDescendentsCompat(
-                self.parent_id)
         else:
             self.publish = False
-            self.parent_id = None
-            self.legacy_pages = []
 
         if self.config.confluence_space_name is not None:
             self.space_name = self.config.confluence_space_name
@@ -300,6 +295,7 @@ class ConfluenceBuilder(Builder):
                     "%s: %s" % (outfilename, err))
 
     def publish_doc(self, docname, output):
+        conf = self.config
         title = ConfluenceState.title(docname)
 
         parent_id = None
@@ -316,7 +312,14 @@ class ConfluenceBuilder(Builder):
         if self.config.master_doc == docname:
             self.master_doc_page_id = uploaded_id
 
-        if self.config.confluence_purge:
+        if conf.confluence_purge and not self.legacy_pages:
+            if conf.confluence_purge_from_master and self.master_doc_page_id:
+                baseid = self.master_doc_page_id
+            else:
+                baseid = self.parent_id
+            self.legacy_pages = self.publisher.getDescendents(baseid)
+
+        if conf.confluence_purge:
             if uploaded_id in self.legacy_pages:
                 self.legacy_pages.remove(uploaded_id)
 
@@ -338,6 +341,9 @@ class ConfluenceBuilder(Builder):
         self.env.get_doctree = self._original_get_doctree
 
         if self.publish:
+            self.legacy_pages = None
+            self.parent_id = self.publisher.getBasePageId()
+
             for docname in ConfluenceCompat.status_iterator(self,
                     self.publish_docnames, 'publishing... ',
                     length=len(self.publish_docnames)):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -219,6 +219,19 @@ class ConfluencePublisher():
 
         return descendents
 
+    def getDescendentsCompat(self, page_id):
+        visited_pages = set()
+
+        def find_legacy_pages(page_id, pages):
+            descendents = self.getDescendents(page_id)
+            for descendent in descendents:
+                if descendent not in pages:
+                    pages.add(descendent)
+                    find_legacy_pages(descendent, pages)
+
+        find_legacy_pages(page_id, visited_pages)
+        return list(visited_pages)
+
     def storePage(self, page_name, raw_data, parent_id=None):
         uploaded_page_id = None
 


### PR DESCRIPTION
Provides two changes related to purging:

- publisher: add compatibility support for descendants fetch
   Corrects an issue observed in Confluence Server where purging descendants with hierarchy mode fail.
- builder: support purging from master_doc base
   Supports purging from a `master_doc` instead of a space root/parent-page (primarily introduced for some upcoming validation set improvements).