### PR TITLE
.travis.yml: add python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
-python: 3.6
 
-env:
-  - TOXENV=py36
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py27
-  - TOXENV=pylint
+matrix:
+  include:
+  - python: "2.7"
+    env: TOXENV=py27
+  - python: "3.4"
+    env: TOXENV=py34
+  - python: "3.5"
+    env: TOXENV=py35
+  - python: "3.6"
+    env: TOXENV=py36
+  - python: "3.6"
+    env: TOXENV=pylint
 
 install:
  - pip install --upgrade tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
-python: 3.5
+python: 3.6
 
 env:
+  - TOXENV=py36
   - TOXENV=py35
   - TOXENV=py34
   - TOXENV=py27


### PR DESCRIPTION
Travis CI instances support Python 3.6 \[1\]; adding the additional environment type. Adding a build matrix \[2\] to explicitly define the respective Python interpreters to use for each tox environment to be tested.

\[1\]: https://docs.travis-ci.com/user/languages/python/#Specifying-Python-versions
\[2\]: https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix