### PR TITLE
Fixed bug for 1-way SSL RPC calls.

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -466,6 +466,7 @@ class ConfluenceTransport(xmlrpclib.Transport):
         """
         xmlrpclib.Transport.__init__(self)
 
+        client_cert = client_cert or (None, None)
         self.disable_ssl_validation = False
         self.scheme = urllib.splittype(server_url)[0]
         self.https = (self.scheme == 'https')
@@ -569,12 +570,14 @@ class ConfluenceTransport(xmlrpclib.Transport):
 
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH,
                                              cafile=cafile, capath=capath)
-        try:
-            context.load_cert_chain(certfile=self._certfile,
-                                    keyfile=self._keyfile,
-                                    password=self.client_cert_pass)
-        except ssl.SSLError as ex:
-            raise ConfluenceCertificateError(ex)
+        if self._certfile:
+            try:
+                context.load_cert_chain(certfile=self._certfile,
+                                        keyfile=self._keyfile,
+                                        password=self.client_cert_pass)
+            except ssl.SSLError as ex:
+                raise ConfluenceCertificateError(ex)
+
         if self.disable_ssl_validation:
             context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE

--- a/test/unit-tests/common/test_publisher.py
+++ b/test/unit-tests/common/test_publisher.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
+    :license: BSD, see LICENSE.txt for details.
+"""
+
+import ssl
+import unittest
+from http.client import HTTPConnection, HTTPSConnection
+
+from sphinxcontrib.confluencebuilder.publisher import ConfluenceTransport
+
+
+class TestConfluenceTransport(unittest.TestCase):
+    def setUp(self):
+        self.http_url = 'http://somehost'
+        self.https_url = 'https://somehost'
+
+    def test_make_connection_already_exists(self):
+        transport = ConfluenceTransport(self.http_url, client_cert=None)
+        connection = transport.make_connection('host')
+        self.assertEqual(connection, transport.make_connection('host'))
+
+    def test_make_http_connection(self):
+        transport = ConfluenceTransport(self.http_url, client_cert=None)
+        connection = transport.make_connection('host')
+        self.assertIsInstance(connection, HTTPConnection)
+
+    def test_make_https_connection_no_client_cert(self):
+        transport = ConfluenceTransport(self.https_url, client_cert=None)
+        connection = transport.make_connection('host')
+        self.assertIsInstance(connection, HTTPSConnection)
+        context = connection._context
+        self.assertEqual(context.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_make_https_connection_disable_validation(self):
+        transport = ConfluenceTransport(self.https_url)
+        transport.disable_ssl_verification()
+        connection = transport.make_connection('host')
+        self.assertIsInstance(connection, HTTPSConnection)
+        context = connection._context
+        self.assertEqual(context.verify_mode, ssl.CERT_NONE)
+
+    def test_make_http_connection_with_client_cert(self):
+        transport = ConfluenceTransport(self.http_url,
+                                        client_cert=("file1", None))
+        connection = transport.make_connection('host')
+        self.assertIsInstance(connection, HTTPConnection)


### PR DESCRIPTION
This resolves an issue such that if the RPC interface is being
used and no client_certificate was provided, an error would be
raised. This prevents this issue.

Signed-off-by: Logan Jones <loganasherjones@gmail.com>