### PR TITLE
builder: incorrectly flagged legacy page(s) on empty descendants

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -315,7 +315,7 @@ class ConfluenceBuilder(Builder):
         if self.config.master_doc == docname:
             self.master_doc_page_id = uploaded_id
 
-        if conf.confluence_purge and not self.legacy_pages:
+        if conf.confluence_purge and self.legacy_pages is None:
             if conf.confluence_purge_from_master and self.master_doc_page_id:
                 baseid = self.master_doc_page_id
             else:


### PR DESCRIPTION
When populating a list of documents to purge from a space, a list of legacy pages is populated once after the first publish attempt (to easily fetch the base page identifier). In the event which the base page does not have any descendants (usually first-ever publish attempt), an empty list is generated and set into `self.legacy_pages`. When this scenario occurs, the next publish page will re-populate the known legacy pages list which could result in pages which have already been flagged as not-legacy as legacy again. To address this, an explicit check is made so that only if `self.legacy_pages` is `None` will a list of descendants be populated.