### PR TITLE
builder: force toctree max-depth's when squashing

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -239,7 +239,8 @@ class ConfluenceBuilder(Builder):
         doctree = self.env.get_doctree(docname)
         for toctreenode in doctree.traverse(addnodes.toctree):
             if not omit and max_depth is not None:
-                if (depth + toctreenode['maxdepth']) > max_depth:
+                if (toctreenode['maxdepth'] == -1 or
+                        depth + toctreenode['maxdepth'] > max_depth):
                     new_depth = max_depth - depth
                     assert new_depth >= 0
                     toctreenode['maxdepth'] = new_depth

--- a/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2a.rst
+++ b/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2a.rst
@@ -9,3 +9,7 @@ hyperlink references (part a)
 Validate `anonymous`__ hyperlink references.
 
 __ http://www.example.com/static/first-link.txt
+
+.. toctree::
+
+   toctree-doc2aa

--- a/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2aa.rst
+++ b/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2aa.rst
@@ -1,0 +1,8 @@
+treedoc2aa
+----------
+
+Page content that should be squashed into a parent page.
+
+.. toctree::
+
+   toctree-doc2aaa

--- a/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2aaa.rst
+++ b/test/unit-tests/toctree/dataset-hierarchy/toctree-doc2aaa.rst
@@ -1,0 +1,4 @@
+treedoc2aaa
+-----------
+
+More page content that should be squashed into a parent page.

--- a/test/unit-tests/toctree/dataset-hierarchy/toctree.rst
+++ b/test/unit-tests/toctree/dataset-hierarchy/toctree.rst
@@ -2,7 +2,6 @@ root
 ----
 
 .. toctree::
-   :maxdepth: 2
 
    toctree-doc1
    toctree-doc2

--- a/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
@@ -4,6 +4,14 @@ h3. hyperlink references (part a)
 
 Validate [anonymous|http://www.example.com/static/first-link.txt] hyperlink references.
 
+h4. treedoc2aa
+
+Page content that should be squashed into a parent page.
+
+h5. treedoc2aaa
+
+More page content that should be squashed into a parent page.
+
 h2. treedoc2b
 
 Jump to either [doc1|treedoc1#example-doc1-label] or [doc2|treedoc3#example-doc3-label].

--- a/test/unit-tests/toctree/test_toctree_hierarchy.py
+++ b/test/unit-tests/toctree/test_toctree_hierarchy.py
@@ -38,6 +38,17 @@ class TestConfluenceToctreeHierarchyMarkup(unittest.TestCase):
         _.assertExpectedWithOutput(
             self, 'toctree-doc3', self.expected, self.doc_dir)
 
+        test_paths = [
+            os.path.join(self.doc_dir, 'toctree-doc2a.conf'),
+            os.path.join(self.doc_dir, 'toctree-doc2aa.conf'),
+            os.path.join(self.doc_dir, 'toctree-doc2aaa.conf'),
+            os.path.join(self.doc_dir, 'toctree-doc2b.conf'),
+            os.path.join(self.doc_dir, 'toctree-doc2c.conf')
+            ]
+        for test_path in test_paths:
+            self.assertFalse(os.path.exists(test_path),
+                'unexpected file was generated: {}'.format(test_path))
+
     def test_parent_registration(self):
         root_doc = ConfluenceState.parentDocname('toctree')
         self.assertIsNone(root_doc, 'root toctree has a parent')


### PR DESCRIPTION
When a documentation's configuration defines a forced maximum depth for pages (`confluence_max_doc_depth`), parent pages will have their maximum depth values changed so that Sphinx doesn't attempt to populate descendants beyond the configured limit. In the event where a document doesn't define a maximum depth inside its toctree, the maximum depth value is translated to a value of "-1". This by-passes the internal maximum depth check. Correcting this by just forcing the maximum depth for toctree's which do not explicitly define one.

This address issue #100.