### PR TITLE
doc: register theme overrides using add_stylesheet

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,10 +102,6 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-    'css_files': [ '_static/theme_overrides.css' ],
-    }
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
@@ -162,5 +158,8 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+# append theme override
+def setup(app):
+    app.add_stylesheet('theme_overrides.css')
 
 


### PR DESCRIPTION
Instead of performing theme corrections using the 'css_files' options, use the application instance's `add_stylesheet` instead. This prevents issues where overriding the theme affects ReadTheDoc's theme \[1\].

\[1\]: https://github.com/rtfd/readthedocs.org/issues/2116