### PR TITLE
Warnings are supposed to be colored but on Windows they are sometimes

### DIFF
--- a/test/sphinxcontrib_confluencebuilder_util.py
+++ b/test/sphinxcontrib_confluencebuilder_util.py
@@ -7,6 +7,7 @@
     :license: BSD, see LICENSE.txt for details.
 """
 
+from sphinx.util.console import nocolor, color_terminal
 from sphinx.application import Sphinx
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 import difflib
@@ -116,6 +117,12 @@ class ConfluenceTestUtil:
 
         [1]: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/application.py
         """
+        # Enable coloring of warning and other messages.  Note that this can
+        # cause sys.stderr to be mocked which is why we pass the new value
+        # explicitly on the call to Sphinx() below.
+        if not color_terminal():
+            nocolor()
+
         sts = ConfluenceTestUtil.default_sphinx_status
         return Sphinx(
             src_dir,                # output for document sources
@@ -123,6 +130,7 @@ class ConfluenceTestUtil:
             out_dir,                # output for generated documents
             doctree_dir,            # output for doctree files
             ConfluenceBuilder.name, # use this extension's builder
-            dict(config),           # load the provided configuration (volatile)
-            sts                     # status output
-            )
+            confoverrides=dict(config), 
+                                    # load the provided configuration (volatile)
+            status=sts,             # status output
+            warning=sys.stderr)     # warnings output


### PR DESCRIPTION
not and are displayed like  '?[31;01mThis is a warning...'.
Colorama is not intercepting the control strings and converting them
into Windows color commands.

Colorama has to be initialized and the resulting sys.stderr mock
passed to Sphinx() to ensure correct colorization.

Signed-off-by: Paul D.Smith <paul_d_smith@hotmail.com>