### PR TITLE
publisher: handle various space names in desc-check

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -205,8 +205,8 @@ class ConfluencePublisher():
             if page_id:
                 search_fields = {'cql': 'ancestor=' + str(page_id)}
             else:
-                search_fields = {'cql': 'space=' + self.space_name +
-                    ' and type=page'}
+                search_fields = {'cql': 'space="' + self.space_name +
+                    '" and type=page'}
 
             # Observed issues with "content/{id}/descendant"; using search.
             rsp = self.rest_client.get('content/search', search_fields)


### PR DESCRIPTION
When a REST-based publishing event checks for page descendants (when purging legacy pages), a CQL search request can be made when attempting to find descendants for a space. The provided space name is not quoted, and causes the CQL expression to break with some valid space name values (for example, personal spaces which are prefixes with a tilde (`~`) character). Enclosing the space name with quotes prevent an expression error.