### PR TITLE
README.rst: show build status on master branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Atlassian Confluence Builder for Sphinx
     :target: https://pypi.python.org/pypi/sphinxcontrib-confluencebuilder
     :alt: pip Version
 
-.. image:: https://img.shields.io/travis/tonybaloney/sphinxcontrib-confluencebuilder.svg
+.. image:: https://travis-ci.org/tonybaloney/sphinxcontrib-confluencebuilder.svg?branch=master
     :target: https://travis-ci.org/tonybaloney/sphinxcontrib-confluencebuilder
     :alt: Build Status
 


### PR DESCRIPTION
When rendering the build status badge on the README, only show the status from the master branch (to avoid pending merge requests from reflecting a bad build state for the repository).