### PR TITLE
.travis.yml: adding python 3.7 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
     env: TOXENV=py35
   - python: "3.6"
     env: TOXENV=py36
+  - python: "3.7"
+    env: TOXENV=py37
+    dist: xenial
+    sudo: true
   - python: "3.6"
     env: TOXENV=pylint
 


### PR DESCRIPTION
Perform integration tests under Python 3.7.