### PR TITLE
builder: improve document title fetching

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -274,6 +274,22 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_remove_title:
             title_element = self._find_title_element(doctree)
             if title_element:
+                # If the removed title is referenced to from within the same
+                # document (i.e. a local table of contents entry), remove the
+                # entry (and parents if empty). This should, in the case of a
+                # table of contents (contents directive), remove the leading
+                # generated title link.
+                if 'refid' in title_element:
+                    for node in doctree.traverse(nodes.reference):
+                        if ('ids' in node
+                                and node['ids'][0] == title_element['refid']):
+                            def remove_until_has_children(node):
+                                parent = node.parent
+                                parent.remove(node)
+                                if not parent.children:
+                                    remove_until_has_children(parent)
+                            remove_until_has_children(node)
+
                 title_element.parent.remove(title_element)
 
         # This method is taken from TextBuilder.write_doc()


### PR DESCRIPTION
_(edit: this feature has been reworked based off observations from #130; see comment history for original content)_

The following attempts to improve the determined title value for a document to be published. Originally, there was "smart" checks to help try exact the leading section's title value from a document. It would only attempt to consider the first node after skipping a series of "no-content nodes" (e.x. comments, etc.). This was to prevent having a bulk of content and then using the first section which exists near the bottom of a document.

The complications from the above approach is that there needs to be a explicit list of node types to verify as "no-content" before taking the next "real" node to consider. While categories like `nodes.Invisible` was tried, not all directive types are properly categorized (in the simplest example, a user could be using custom directives and do not really care of what categories they are in).

Instead of having a list of skippable leading nodes, just look for the first section element. This should produce a most likely desired title value for a document for most users.
