### PR TITLE
publisher: handle confluence transaction failure

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -29,6 +29,7 @@ import os
 import socket
 import ssl
 import sys
+import time
 
 try:
     import http.client as httplib
@@ -354,7 +355,23 @@ class ConfluencePublisher():
                     if parent_id:
                         updatePage['ancestors'] = [{'id': parent_id}]
 
-                    self.rest_client.put('content', page['id'], updatePage)
+                    try:
+                        self.rest_client.put('content', page['id'], updatePage)
+                    except ConfluenceBadApiError as ex:
+                        # Confluence Cloud may (rarely) fail to complete a
+                        # content request with an OptimisticLockException/
+                        # StaleObjectStateException exception. It is suspected
+                        # that this is just an instance timing/processing issue.
+                        # If this is observed, wait a moment and retry the
+                        # content request. If it happens again, the put request
+                        # will fail as it normally would.
+                        if str(ex).find('OptimisticLockException') == -1:
+                            raise
+                        ConfluenceLogger.warn(
+                            'remote page updated failed; retrying...')
+                        time.sleep(1)
+                        self.rest_client.put('content', page['id'], updatePage)
+
                     uploaded_page_id = page['id']
             except ConfluencePermissionError:
                 raise ConfluencePermissionError(


### PR DESCRIPTION
Confluence Cloud may (rarely) fail to complete a content request with an `OptimisticLockException`/ `StaleObjectStateException` exception:
```
    com.atlassian.confluence.core.persistence.confluence.StaleObjectStateException: javax.persistence.OptimisticLockException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1
```
It is suspected that this is just an instance timing/processing issue. If this is observed, wait a moment and retry the content request. If it happens again, the put request will fail as it normally would. This should assist in users when publishing large document sets (200+).