### PR TITLE
provide a password prompt option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -37,15 +37,29 @@ confluence_server_pass
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The password value used to authenticate with the Confluence instance. If using
-Confluence Cloud, it is recommended to use an API token (if supported) for the
-configured username value (see api_tokens_). If API tokens are not being used,
-the plain password for the configured username value should be used.
+Confluence Cloud, it is recommended to use an API token for the configured
+username value (see `API tokens`_):
 
 .. code-block:: python
 
    confluence_server_pass = 'vsUsrSZ6Z4kmrQMapSXBYkJh'
-       (or)
+
+If `API tokens`_ are not being used, the plain password for the configured
+username value should be used:
+
+.. code-block:: python
+
    confluence_server_pass = 'myawesomepassword'
+
+.. caution::
+
+   It is never recommended to store an API token or raw password into a
+   committed/shared repository holding documentation. A documentation's
+   configuration can modified various ways with Python to pull an
+   authentication token for a publishing event (reading from a local file,
+   acquiring a password from ``getpass``, etc.). If desired, this extension
+   provides a method for prompting for a password (see
+   |confluence_ask_password|_).
 
 confluence_server_url
 ~~~~~~~~~~~~~~~~~~~~~
@@ -353,6 +367,9 @@ option is enabled with a value of ``True``.
 advanced configuration - publishing
 -----------------------------------
 
+.. |confluence_ask_password| replace:: ``confluence_ask_password``
+.. _confluence_ask_password:
+
 confluence_ask_password
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -550,6 +567,7 @@ seconds, the following can be used:
 
 .. references ------------------------------------------------------------------
 
+.. _API tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
 .. _Confluence-supported syntax highlight languages: https://confluence.atlassian.com/confcloud/code-block-macro-724765175.html
 .. _Pygments documented language types: http://pygments.org/docs/lexers/
 .. _Requests SSL Cert Verification: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -353,6 +353,39 @@ option is enabled with a value of ``True``.
 advanced configuration - publishing
 -----------------------------------
 
+confluence_ask_password
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   User's running Cygwin/MinGW may need to invoke with ``winpty`` to allow this
+   feature to work.
+
+Provides an override for an interactive shell to request publishing documents
+using an API key or password provided from the shell environment. While a
+password is typically defined in the option ``confluence_server_pass`` (either
+directly set/fetched from the project's ``config.py`` or passed via a command
+line argument ``-D confluence_server_pass=password``), select environments may
+wish to provide a way to provide an authentication token without needing to
+modify documentation sources or having a visible password value in the
+interactive session requesting the publish event. By default, this
+option is disabled with a value of ``False``.
+
+.. code-block:: python
+
+   confluence_remove_title = False
+
+A user can request for a password prompt by invoking build event by passing the
+define through the command line:
+
+.. code-block:: none
+
+   sphinx-build [options] -D confluence_ask_password=1 <srcdir> <outdir>
+
+Note that some shell sessions may not be able to pull the password value
+properly from the user. For example, Cygwin/MinGW may not be able to accept a
+password unless invoked with ``winpty``.
+
 confluence_ca_cert
 ~~~~~~~~~~~~~~~~~~
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -78,6 +78,8 @@ def setup(app):
     app.add_config_value('confluence_remove_title', True, False)
 
     """(advanced-configuration - publishing)"""
+    """Request for publish password to come from interactive session."""
+    app.add_config_value('confluence_ask_password', False, False)
     """File/path to Certificate Authority"""
     app.add_config_value('confluence_ca_cert', None, False)
     """Path to client certificate to use for publishing"""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -15,11 +15,13 @@ from .util import ConfluenceUtil
 from .writer import ConfluenceWriter
 from docutils import nodes
 from docutils.io import StringOutput
+from getpass import getpass
 from os import path
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.util.osutil import ensuredir, SEP
 import io
+import sys
 
 # Clone of relative_uri() sphinx.util.osutil, with bug-fixes
 # since the original code had a few errors.
@@ -69,6 +71,16 @@ class ConfluenceBuilder(Builder):
     def init(self, suppress_conf_check=False):
         if not ConfluenceConfig.validate(self.config, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
+
+        if self.config.confluence_ask_password:
+            print('(request to accept password from interactive session)')
+            print(' Instance: ' + self.config.confluence_server_url)
+            print('     User: ' + self.config.confluence_server_user)
+            sys.stdout.write(' Password: ')
+            sys.stdout.flush()
+            self.config.confluence_server_pass = getpass('')
+            if not self.config.confluence_server_pass:
+                raise ConfluenceConfigurationError('no password provided')
 
         self.writer = ConfluenceWriter(self)
         self.config.sphinx_verbosity = self.app.verbosity


### PR DESCRIPTION
Introduces a new option `confluence_ask_password` to allow a user to request this extension to prompt for a password to be used for authenticating with a publish event to the configured Confluence instance.

This feature is to assist in user's who wish to invoke a publish request on a documentation set without having to manually adjust the documentation's configuration, setup external environment/files or provide a clear password in an interactive session. With this feature, user's can invoke a build with the following option to a password prompt to appear:

```
sphinx-build [options] -D confluence_ask_password=1 <srcdir> <outdir>
```

This commit explicitly leaves the `getpass` prompt value as empty and provides the prompt information using system write calls. This is to provide more feedback for Cygwin/MinGW sessions (invoked without `winpty`) which cannot handle pulling a password from `getpass` (instead of the session blocking with no input provided).

This change has been introduced based off comments from issue #96.