### PR TITLE
rest: output more detailed rest failures

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -209,7 +209,7 @@ class Rest:
         err += "URL: " + self.url + API_REST_BIND_PATH + "\n"
         err += "API: " + key + "\n"
         try:
-            err += 'MSG: {}'.format(rsp.json()['message'])
-        except ValueError:
-            err += 'MSG: <not-or-invalid-json>'
+            err += 'DATA: {}'.format(json.dumps(rsp.json(), indent=2))
+        except TypeError:
+            err += 'DATA: <not-or-invalid-json>'
         return err


### PR DESCRIPTION
When an error occurs interacting with a Confluence instance, some advanced error cannot be completely interpreted from the provided `message` content. In addition to the message, Confluence may populate more notifications inside `'data': { 'errors': [...] }`. To handle this and possibly other odd scenarios, just dump the entire response data in the event of an unknown error.