### PR TITLE
translator: allow inline markup inside references

### DIFF
--- a/test/unit-tests/common/dataset-common/references.rst
+++ b/test/unit-tests/common/dataset-common/references.rst
@@ -52,3 +52,13 @@ sub-section
 section :ref:`my-reference-label2`.
 
 :ref:`internal anchor <my-reference-label1>`.
+
+.. escaped check --- > should be escaped ---------------------------------------
+
+`> <https://example.com/>`_
+
+.. inline markup should work inside (most) references --------------------------
+
+.. |a link| replace:: **a bolded link**
+
+|a link|_

--- a/test/unit-tests/common/expected/citations.conf
+++ b/test/unit-tests/common/expected/citations.conf
@@ -2,13 +2,13 @@
     <ac:parameter ac:name="">id1</ac:parameter>
     </ac:structured-macro>
     <sup><ac:link ac:anchor="cit01">
-    <ac:plain-text-link-body><![CDATA[[CIT01]]]></ac:plain-text-link-body>
+    <ac:link-body>[CIT01]</ac:link-body>
 </ac:link></sup></p>
 <p>content <ac:structured-macro ac:name="anchor">
     <ac:parameter ac:name="">id2</ac:parameter>
     </ac:structured-macro>
     <sup><ac:link ac:anchor="cit02">
-    <ac:plain-text-link-body><![CDATA[[CIT02]]]></ac:plain-text-link-body>
+    <ac:link-body>[CIT02]</ac:link-body>
 </ac:link></sup></p>
 <table>
     <tbody>

--- a/test/unit-tests/common/expected/glossary-ref.conf
+++ b/test/unit-tests/common/expected/glossary-ref.conf
@@ -1,12 +1,12 @@
 <p><ac:link ac:anchor="term-glossary-1">
     <ri:page ri:content-title="glossary" />
-    <ac:plain-text-link-body><![CDATA[glossary 1]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 1</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="term-glossary-2">
     <ri:page ri:content-title="glossary" />
-    <ac:plain-text-link-body><![CDATA[glossary 2]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 2</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="term-glossary-3">
     <ri:page ri:content-title="glossary" />
-    <ac:plain-text-link-body><![CDATA[glossary 3]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 3</ac:link-body>
 </ac:link></p>

--- a/test/unit-tests/common/expected/glossary.conf
+++ b/test/unit-tests/common/expected/glossary.conf
@@ -27,11 +27,11 @@
     </dd>
 </dl>
 <p><ac:link ac:anchor="term-glossary-1">
-    <ac:plain-text-link-body><![CDATA[glossary 1]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 1</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="term-glossary-2">
-    <ac:plain-text-link-body><![CDATA[glossary 2]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 2</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="term-glossary-3">
-    <ac:plain-text-link-body><![CDATA[glossary 3]]></ac:plain-text-link-body>
+    <ac:link-body>glossary 3</ac:link-body>
 </ac:link></p>

--- a/test/unit-tests/common/expected/references-ref.conf
+++ b/test/unit-tests/common/expected/references-ref.conf
@@ -1,16 +1,16 @@
 <p>document link <ac:link>
     <ri:page ri:content-title="references" />
-    <ac:plain-text-link-body><![CDATA[references]]></ac:plain-text-link-body>
+    <ac:link-body>references</ac:link-body>
 </ac:link></p>
 <p>document with <ac:link>
     <ri:page ri:content-title="references" />
-    <ac:plain-text-link-body><![CDATA[custom name]]></ac:plain-text-link-body>
+    <ac:link-body>custom name</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="my-reference-label1">
     <ri:page ri:content-title="references" />
-    <ac:plain-text-link-body><![CDATA[references anchor]]></ac:plain-text-link-body>
+    <ac:link-body>references anchor</ac:link-body>
 </ac:link></p>
 <p><ac:link ac:anchor="sub-section">
     <ri:page ri:content-title="references" />
-    <ac:plain-text-link-body><![CDATA[references section]]></ac:plain-text-link-body>
+    <ac:link-body>references section</ac:link-body>
 </ac:link></p>

--- a/test/unit-tests/common/expected/references.conf
+++ b/test/unit-tests/common/expected/references.conf
@@ -10,11 +10,11 @@
 <p>leading <a href="https://example.com/">custom name</a> trailing</p>
 <p>document link <ac:link>
     <ri:page ri:content-title="references-ref" />
-    <ac:plain-text-link-body><![CDATA[references-ref]]></ac:plain-text-link-body>
+    <ac:link-body>references-ref</ac:link-body>
 </ac:link></p>
 <p>document with <ac:link>
     <ri:page ri:content-title="references-ref" />
-    <ac:plain-text-link-body><![CDATA[custom name]]></ac:plain-text-link-body>
+    <ac:link-body>custom name</ac:link-body>
 </ac:link></p>
 <ac:structured-macro ac:name="anchor">
     <ac:parameter ac:name="">my-reference-label1</ac:parameter>
@@ -22,8 +22,8 @@
 <p>dummy content to generate above anchor</p>
 <h1>sub-section</h1>
 <p>section <ac:link ac:anchor="sub-section">
-    <ac:plain-text-link-body><![CDATA[sub-section]]></ac:plain-text-link-body>
+    <ac:link-body>sub-section</ac:link-body>
 </ac:link>.</p>
 <p><ac:link ac:anchor="my-reference-label1">
-    <ac:plain-text-link-body><![CDATA[internal anchor]]></ac:plain-text-link-body>
+    <ac:link-body>internal anchor</ac:link-body>
 </ac:link>.</p>

--- a/test/unit-tests/common/expected/references.conf
+++ b/test/unit-tests/common/expected/references.conf
@@ -27,3 +27,5 @@
 <p><ac:link ac:anchor="my-reference-label1">
     <ac:link-body>internal anchor</ac:link-body>
 </ac:link>.</p>
+<p><a href="https://example.com/">&gt;</a></p>
+<p><a href="https://example.com/"><strong>a bolded link</strong></a></p>

--- a/test/unit-tests/toctree/expected-def/contents.conf
+++ b/test/unit-tests/toctree/expected-def/contents.conf
@@ -2,39 +2,39 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="doca" />
-        <ac:plain-text-link-body><![CDATA[doca]]></ac:plain-text-link-body>
+        <ac:link-body>doca</ac:link-body>
         </ac:link><ul>
             <li>
                 <ac:link>
                     <ri:page ri:content-title="doca1" />
-                    <ac:plain-text-link-body><![CDATA[doca1]]></ac:plain-text-link-body>
+                    <ac:link-body>doca1</ac:link-body>
                 </ac:link></li>
             <li>
                 <ac:link>
                     <ri:page ri:content-title="doca2" />
-                    <ac:plain-text-link-body><![CDATA[doca2]]></ac:plain-text-link-body>
+                    <ac:link-body>doca2</ac:link-body>
                 </ac:link></li>
         </ul>
     </li>
     <li>
         <ac:link>
         <ri:page ri:content-title="docb" />
-        <ac:plain-text-link-body><![CDATA[docb]]></ac:plain-text-link-body>
+        <ac:link-body>docb</ac:link-body>
         </ac:link><ul>
             <li>
                 <ac:link ac:anchor="docbsubheader1">
                 <ri:page ri:content-title="docb" />
-                <ac:plain-text-link-body><![CDATA[docbsubheader1]]></ac:plain-text-link-body>
+                <ac:link-body>docbsubheader1</ac:link-body>
                 </ac:link><ul>
                     <li>
                         <ac:link ac:anchor="docbsubheader2">
                         <ri:page ri:content-title="docb" />
-                        <ac:plain-text-link-body><![CDATA[docbsubheader2]]></ac:plain-text-link-body>
+                        <ac:link-body>docbsubheader2</ac:link-body>
                         </ac:link><ul>
                             <li>
                                 <ac:link>
                                     <ri:page ri:content-title="docb1" />
-                                    <ac:plain-text-link-body><![CDATA[docb1]]></ac:plain-text-link-body>
+                                    <ac:link-body>docb1</ac:link-body>
                                 </ac:link></li>
                         </ul>
                     </li>
@@ -45,37 +45,37 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="docc" />
-        <ac:plain-text-link-body><![CDATA[docc]]></ac:plain-text-link-body>
+        <ac:link-body>docc</ac:link-body>
         </ac:link><ul>
             <li>
                 <ac:link ac:anchor="doccsubheader1">
                 <ri:page ri:content-title="docc" />
-                <ac:plain-text-link-body><![CDATA[doccsubheader1]]></ac:plain-text-link-body>
+                <ac:link-body>doccsubheader1</ac:link-body>
                 </ac:link><ul>
                     <li>
                         <ac:link ac:anchor="doccsubheader2">
                         <ri:page ri:content-title="docc" />
-                        <ac:plain-text-link-body><![CDATA[doccsubheader2]]></ac:plain-text-link-body>
+                        <ac:link-body>doccsubheader2</ac:link-body>
                         </ac:link><ul>
                             <li>
                                 <ac:link ac:anchor="doccsubheader3">
                                 <ri:page ri:content-title="docc" />
-                                <ac:plain-text-link-body><![CDATA[doccsubheader3]]></ac:plain-text-link-body>
+                                <ac:link-body>doccsubheader3</ac:link-body>
                                 </ac:link><ul>
                                     <li>
                                         <ac:link>
                                             <ri:page ri:content-title="docc1" />
-                                            <ac:plain-text-link-body><![CDATA[docc1]]></ac:plain-text-link-body>
+                                            <ac:link-body>docc1</ac:link-body>
                                         </ac:link></li>
                                     <li>
                                         <ac:link>
                                             <ri:page ri:content-title="docc2" />
-                                            <ac:plain-text-link-body><![CDATA[docc2]]></ac:plain-text-link-body>
+                                            <ac:link-body>docc2</ac:link-body>
                                         </ac:link></li>
                                     <li>
                                         <ac:link>
                                             <ri:page ri:content-title="docc3" />
-                                            <ac:plain-text-link-body><![CDATA[docc3]]></ac:plain-text-link-body>
+                                            <ac:link-body>docc3</ac:link-body>
                                         </ac:link></li>
                                 </ul>
                             </li>

--- a/test/unit-tests/toctree/expected-def/doca.conf
+++ b/test/unit-tests/toctree/expected-def/doca.conf
@@ -2,11 +2,11 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="doca1" />
-            <ac:plain-text-link-body><![CDATA[doca1]]></ac:plain-text-link-body>
+            <ac:link-body>doca1</ac:link-body>
         </ac:link></li>
     <li>
         <ac:link>
         <ri:page ri:content-title="doca2" />
-            <ac:plain-text-link-body><![CDATA[doca2]]></ac:plain-text-link-body>
+            <ac:link-body>doca2</ac:link-body>
         </ac:link></li>
 </ul>

--- a/test/unit-tests/toctree/expected-def/docb.conf
+++ b/test/unit-tests/toctree/expected-def/docb.conf
@@ -4,6 +4,6 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="docb1" />
-            <ac:plain-text-link-body><![CDATA[docb1]]></ac:plain-text-link-body>
+            <ac:link-body>docb1</ac:link-body>
         </ac:link></li>
 </ul>

--- a/test/unit-tests/toctree/expected-def/docc.conf
+++ b/test/unit-tests/toctree/expected-def/docc.conf
@@ -5,16 +5,16 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="docc1" />
-            <ac:plain-text-link-body><![CDATA[docc1]]></ac:plain-text-link-body>
+            <ac:link-body>docc1</ac:link-body>
         </ac:link></li>
     <li>
         <ac:link>
         <ri:page ri:content-title="docc2" />
-            <ac:plain-text-link-body><![CDATA[docc2]]></ac:plain-text-link-body>
+            <ac:link-body>docc2</ac:link-body>
         </ac:link></li>
     <li>
         <ac:link>
         <ri:page ri:content-title="docc3" />
-            <ac:plain-text-link-body><![CDATA[docc3]]></ac:plain-text-link-body>
+            <ac:link-body>docc3</ac:link-body>
         </ac:link></li>
 </ul>

--- a/test/unit-tests/toctree/expected-hierarchy/toctree-doc1.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree-doc1.conf
@@ -3,5 +3,5 @@
 </ac:structured-macro>
 <p>Go to <ac:link ac:anchor="checkcitations">
     <ri:page ri:content-title="treedoc2" />
-    <ac:plain-text-link-body><![CDATA[doc2c]]></ac:plain-text-link-body>
+    <ac:link-body>doc2c</ac:link-body>
 </ac:link>.</p>

--- a/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
@@ -8,11 +8,11 @@
 <h2>treedoc2b</h2>
 <p>Jump to either <ac:link ac:anchor="example-doc1-label">
     <ri:page ri:content-title="treedoc1" />
-    <ac:plain-text-link-body><![CDATA[doc1]]></ac:plain-text-link-body>
+    <ac:link-body>doc1</ac:link-body>
 </ac:link> or
 <ac:link ac:anchor="example-doc3-label">
     <ri:page ri:content-title="treedoc3" />
-    <ac:plain-text-link-body><![CDATA[doc2]]></ac:plain-text-link-body>
+    <ac:link-body>doc2</ac:link-body>
 </ac:link>.</p>
 <h2>treedoc2c</h2>
 <h3>check citations</h3>
@@ -20,7 +20,7 @@
 <ac:parameter ac:name="">id1</ac:parameter>
 </ac:structured-macro>
 <sup><ac:link ac:anchor="cit2001">
-<ac:plain-text-link-body><![CDATA[[CIT2001]]]></ac:plain-text-link-body>
+<ac:link-body>[CIT2001]</ac:link-body>
 </ac:link></sup>.</p>
 <table>
     <tbody>

--- a/test/unit-tests/toctree/expected-hierarchy/toctree-doc3.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree-doc3.conf
@@ -3,5 +3,5 @@
 </ac:structured-macro>
 <p>Go to <ac:link ac:anchor="hyperlinkreferences(parta)">
 <ri:page ri:content-title="treedoc2" />
-<ac:plain-text-link-body><![CDATA[doc2a]]></ac:plain-text-link-body>
+<ac:link-body>doc2a</ac:link-body>
 </ac:link>.</p>

--- a/test/unit-tests/toctree/expected-hierarchy/toctree.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree.conf
@@ -2,16 +2,16 @@
     <li>
         <ac:link>
         <ri:page ri:content-title="treedoc1" />
-        <ac:plain-text-link-body><![CDATA[treedoc1]]></ac:plain-text-link-body>
+        <ac:link-body>treedoc1</ac:link-body>
         </ac:link></li>
     <li>
         <ac:link>
         <ri:page ri:content-title="treedoc2" />
-        <ac:plain-text-link-body><![CDATA[treedoc2]]></ac:plain-text-link-body>
+        <ac:link-body>treedoc2</ac:link-body>
         </ac:link></li>
     <li>
         <ac:link>
         <ri:page ri:content-title="treedoc3" />
-        <ac:plain-text-link-body><![CDATA[treedoc3]]></ac:plain-text-link-body>
+        <ac:link-body>treedoc3</ac:link-body>
         </ac:link></li>
 </ul>

--- a/test/validation-sets/common/references.rst
+++ b/test/validation-sets/common/references.rst
@@ -24,6 +24,13 @@ inline links within a single paragraph.
    /home
    /index
 
+Hyperlinks should also attempt to maintain support for inline markup where
+possible. For example, |this example link|_ should be bolded.
+
+.. _this example link: http://www.example.com
+
+.. |this example link| replace:: **this example link**
+
 hyperlinks
 ----------
 


### PR DESCRIPTION
The original reference processing pulled the reference label information from the node (or the children of the reference node) and built a link before skipping the processing of the remainder of the node. This breaks the ability to render inline content that can be wrapped around a reference node. For example, the following reStructuredText markup should allow the construction of a bolded link:

    .. _a link: https://example.com/

    .. |a link| replace:: **a bolded link**

    |a link|_

Adjusting reference processing to not invoke pruning exception (when possible to render inline markup). Due to various reference types, it is not ideal to populate the internal `self.context` array. Instead, a new interim context array `self._reference_context` can be populated and each entry will be pop'ed when the reference processing is completed (this works for references since it is (_should_) not be possible to have references inside other references.

In order to support links to internal documents with inline markup support, switching from a plain-text-link-body to a link-body type tag. This element supports plain or rich text content and the content should already be escaped (via other internal node content producers).

This is primarily being introduced to support future image linking support.