### PR TITLE
test: improve verbose argument

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -26,7 +26,7 @@ def main():
     suite  = unittest.TestSuite()
 
     # toggle verbose mode (if provided)
-    if '-v' in sys.argv:
+    if '--verbose' in sys.argv or '-V' in sys.argv:
         ConfluenceTestUtil.enableVerbose()
 
     # discover unit tests


### PR DESCRIPTION
When testing, an original method to view a more verbose output was to use the `-v` argument. However, `--verbose` or `-V` options are more common flags to use; adjusting.