### PR TITLE
additional quote based directives

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -43,7 +43,7 @@ enumerated lists       supported     - `reStructuredText Enumerated Lists`_
 epigraph               supported     - `reStructuredText Epigraph`_
 footnotes              supported     - `reStructuredText Footnotes`_
 glossary               supported     - `Sphinx Glossary`_
-highlights             prospect      - `reStructuredText Highlights`_
+highlights             supported     - `reStructuredText Highlights`_
 hlist                  unsupported   - `Sphinx Horizontal List`_
 hyperlink targets      supported     - `reStructuredText Hyperlink Targets`_
 images                 prospect      - `reStructuredText Images`_
@@ -56,7 +56,7 @@ literal blocks         supported     - `reStructuredText Literal Blocks`_
 math                   unplanned     - `reStructuredText Math`_
 option lists           supported     - `reStructuredText Option Lists`_
 production list        supported     - `Sphinx Production List`_
-pull-quote             prospect      - `reStructuredText Pull-Quote`_
+pull-quote             supported     - `reStructuredText Pull-Quote`_
 raw                    supported     - `reStructuredText Raw Data Pass-Through`_
 rubric                 supported     - `Sphinx Rubric`_
 sections               supported     - `reStructuredText Sections`_

--- a/test/unit-tests/common/dataset-common/epigraph.rst
+++ b/test/unit-tests/common/dataset-common/epigraph.rst
@@ -1,9 +1,25 @@
 :orphan:
 
 .. http://docutils.sourceforge.net/docs/ref/rst/directives.html#epigraph
+.. http://docutils.sourceforge.net/docs/ref/rst/directives.html#highlights
+.. http://docutils.sourceforge.net/docs/ref/rst/directives.html#pull-quote
 
-epigraph
---------
+epigraph, highlight and pull-quote
+----------------------------------
+
+.. epigraph::
+
+    quote
+
+    -- source
+
+.. highlights::
+
+    quote
+
+    -- source
+
+.. pull-quote::
 
     quote
 

--- a/test/unit-tests/common/expected/epigraph.conf
+++ b/test/unit-tests/common/expected/epigraph.conf
@@ -1,2 +1,6 @@
 <blockquote><p>quote</p>
 -- source</blockquote>
+<blockquote><p>quote</p>
+-- source</blockquote>
+<blockquote><p>quote</p>
+-- source</blockquote>

--- a/test/validation-sets/common/other.rst
+++ b/test/validation-sets/common/other.rst
@@ -17,11 +17,25 @@ will be captured inside a Confluence quote block:
 
    -- Sherlock Holmes
 
-epigraph
---------
+epigraph, highlight and pull-quote
+----------------------------------
 
-reStructuredText's `epigraphs`_ should be captured inside a Confluence quote
-block:
+reStructuredText's `epigraphs`_, `highlights`_ and `pull-quotes`_ should be
+captured inside a Confluence quote block:
+
+.. epigraph::
+
+   No matter where you go, there you are.
+
+   -- Buckaroo Banzai
+
+.. highlights::
+
+   No matter where you go, there you are.
+
+   -- Buckaroo Banzai
+
+.. pull-quote::
 
    No matter where you go, there you are.
 
@@ -39,3 +53,5 @@ This is my content.
 .. _block quote: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes
 .. _transitions: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#transitions
 .. _epigraphs: http://docutils.sourceforge.net/docs/ref/rst/directives.html#epigraph
+.. _highlights: http://docutils.sourceforge.net/docs/ref/rst/directives.html#highlights
+.. _pull-quotes: http://docutils.sourceforge.net/docs/ref/rst/directives.html#pull-quote


### PR DESCRIPTION
When adding support for the `epigraph` directive, the implementation also supported both the `highlights` and `pull-quote` directives. Adding a unit/validation test to confirmation and future sanity checks as well as updating the supported-markup document.