### PR TITLE
add parsed literal support

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -54,6 +54,7 @@ list table             supported     - `reStructuredText List Table`_
                                        ``widths``.
 literal blocks         supported     - `reStructuredText Literal Blocks`_
 math                   unplanned     - `reStructuredText Math`_
+parsed literal block   supported     - `reStructuredText Parsed Literal Block`_
 option lists           supported     - `reStructuredText Option Lists`_
 production list        supported     - `Sphinx Production List`_
 pull-quote             prospect      - `reStructuredText Pull-Quote`_
@@ -107,6 +108,7 @@ expected or brings up another concern, feel free to bring up an issue:
 .. _reStructuredText Literal Blocks: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#literal-blocks
 .. _reStructuredText Math: http://docutils.sourceforge.net/docs/ref/rst/directives.html#math
 .. _reStructuredText Option Lists: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#option-lists
+.. _reStructuredText Parsed Literal Block: http://docutils.sourceforge.net/docs/ref/rst/directives.html#parsed-literal-block
 .. _reStructuredText Pull-Quote: http://docutils.sourceforge.net/docs/ref/rst/directives.html#pull-quote
 .. _reStructuredText Raw Data Pass-Through: http://docutils.sourceforge.net/docs/ref/rst/directives.html#raw-data-pass-through
 .. _reStructuredText Sections: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -477,6 +477,18 @@ class ConfluenceTranslator(BaseTranslator):
     # -------------------------------
 
     def visit_literal_block(self, node):
+        is_parsed_literal = node.rawsource != node.astext()
+        if is_parsed_literal:
+            self.body.append(self._start_tag(node, 'div', suffix=self.nl,
+                **{'class': 'panel pdl'}))
+            self.context.append(self._end_tag(node))
+            self.body.append(self._start_tag(node, 'pre',
+                **{'class': 'panelContent'}))
+            self.context.append(self._end_tag(node))
+            self.body.append(self._start_tag(node, 'code'))
+            self.context.append(self._end_tag(node))
+            return
+
         lang = node.get('language', self._highlight).lower()
         if self.builder.lang_transform:
             lang = self.builder.lang_transform(lang)
@@ -515,6 +527,12 @@ class ConfluenceTranslator(BaseTranslator):
                 node, 'hr', suffix=self.nl, empty=True))
 
         raise nodes.SkipNode
+
+    def depart_literal_block(self, node):
+        # note: depart is only invoked for parsed-literals
+        self.body.append(self.context.pop()) # code
+        self.body.append(self.context.pop()) # pre
+        self.body.append(self.context.pop()) # div
 
     def visit_highlightlang(self, node):
         self._highlight = node.get('lang', DEFAULT_HIGHLIGHT_STYLE)

--- a/test/unit-tests/common/dataset-common/parsed-literal.rst
+++ b/test/unit-tests/common/dataset-common/parsed-literal.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+.. http://docutils.sourceforge.net/docs/ref/rst/directives.html#parsed-literal-block
+
+parsed literal
+--------------
+
+.. parsed-literal::
+
+   **markup** content

--- a/test/unit-tests/common/expected/parsed-literal.conf
+++ b/test/unit-tests/common/expected/parsed-literal.conf
@@ -1,0 +1,4 @@
+<div class="panel pdl">
+<pre class="panelContent"><code><strong>markup</strong> content</code>
+</pre>
+</div>

--- a/test/unit-tests/common/test_common.py
+++ b/test/unit-tests/common/test_common.py
@@ -74,6 +74,9 @@ class TestConfluenceCommon(unittest.TestCase):
     def test_option_lists(self):
         self._assertExpectedWithOutput('option-lists')
 
+    def test_parsed_literal(self):
+        self._assertExpectedWithOutput('parsed-literal')
+
     def test_production_list(self):
         self._assertExpectedWithOutput('production-list')
 

--- a/test/validation-sets/common/code.rst
+++ b/test/validation-sets/common/code.rst
@@ -63,4 +63,17 @@ doctest entries should display a code markup styled in Python:
 >>> print "This is a doctest block."
 This is a doctest block.
 
+Documentation may included `parsed literals`_. While parsed literals cannot take
+advantage of Confluence's code macros, it is important that the content is
+rendered with the document-defined inline markup:
+
+.. parsed-literal::
+
+   def main():
+       **print 'Hello, world!'**
+
+   if __name__ == '__main__':
+       main()
+
 .. _Sphinx's code markup: http://www.sphinx-doc.org/en/stable/markup/code.html
+.. _parsed literals: http://docutils.sourceforge.net/docs/ref/rst/directives.html#parsed-literal-block


### PR DESCRIPTION
Adds support for the parsed literal block directive \[1\]. Unlike the regular literal block where content is thrown into a Confluence code macro for styling, users are explicitly providing custom inline markup for the body content. When a parsed literal block is detected (via the `rawsource` comparison check \[2\]), add a series of wrapping tags and let the translator properly fill the contents. The container tags will include panel-based class styles to mimic Confluence's code macro wrapping (i.e. the indentation, borders and padding).

\[1\]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#parsed-literal-block
\[2\]: https://github.com/sphinx-doc/sphinx/blob/004b68f281dbad6e7598c8c2f56945bb3bc07107/sphinx/writers/html5.py#L367