### PR TITLE
translator: add interim math handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1051,6 +1051,22 @@ class ConfluenceTranslator(BaseTranslator):
         # glossary index information is not needed; skipped
         raise nodes.SkipNode
 
+    # --------------
+    # sphinx -- math
+    # --------------
+
+    def visit_math(self, node):
+        # unsupported
+        raise nodes.SkipNode
+
+    def visit_displaymath(self, node):
+        # unsupported
+        raise nodes.SkipNode
+
+    def visit_eqref(self, node):
+        # unsupported
+        raise nodes.SkipNode
+
     # -------------------------
     # sphinx -- production list
     # -------------------------


### PR DESCRIPTION
Add a series of node translation hooks for Sphinx's `math` capability, This is to prevent a hard failure (`unknown_visit`) if a user's document contains math-related directives.