### PR TITLE
doc: theme improvement for wider viewport

### DIFF
--- a/doc/_static/theme_overrides.css
+++ b/doc/_static/theme_overrides.css
@@ -1,4 +1,11 @@
 
+@media screen {
+    /* allow the use of the entire viewport width */
+    .wy-nav-content {
+        max-width: none;
+    }
+}
+ 
 .wy-table-responsive table td {
     /* allow table contents to wrap (corrects bullet list issues) */
     white-space: normal !important;


### PR DESCRIPTION
Override the default Read the Docs theme by allowing the content viewport to not have a restricted width. This allows content to expand beyond the 800px limit (to use the full page; in a similar fashion as the Kernel's documentation does).