### PR TITLE
translator: correct next-child check for indent styling

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -592,7 +592,7 @@ class ConfluenceTranslator(BaseTranslator):
             # for now.
             firstchild_margin = True
             next_child = node.traverse(include_self=False)
-            if isinstance(next_child[0], nodes.block_quote):
+            if next_child and isinstance(next_child[0], nodes.block_quote):
                 firstchild_margin = False
 
             if firstchild_margin:


### PR DESCRIPTION
When docutils block quotes are processed for indented paragraph blocks, child values are checked to help build consistent look-and-feel when various block levels are in play. The traverse check to detect if a node is a first-child will directly attempt to check the first element in the list; however, there is no guarantee that any children will exist (thus causing an `IndexError` exception).

Adjusting the check to ensure the next-child value actually has elements to check against.