### PR TITLE
Strip anchor before trying to determine doctitle

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -821,7 +821,7 @@ class ConfluenceTranslator(BaseTranslator):
 
     def _visit_reference_intern_uri(self, node):
         docname = posixpath.normpath(
-            self.docparent + path.splitext(node['refuri'])[0])
+            self.docparent + path.splitext(node['refuri'].split('#')[0])[0])
         doctitle = ConfluenceState.title(docname)
         if not doctitle:
             ConfluenceLogger.warn('unable to build link to document due to '


### PR DESCRIPTION
I had the same issue as #144, this change seems to fix the issue for internal links with anchors.