### PR TITLE
Add YAML and Sass to the Pygments lexer to Confluence language map.

### DIFF
--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -113,12 +113,16 @@ LITERAL2LANG_MAP = {
     'duby': 'ruby',
     'rb': 'ruby',
     'ruby': 'ruby',
+    # Sass
+    'sass': 'sass',
     # Scala
     'scala': 'scala',
     # SQL
     'sql': 'sql',
     # Visual Basic
     'vb': 'vb',
+    # YAML (Confluence Server >=6.7)
+    'yaml': 'yaml',
     # (special)
     # Sphinx's default highlight language is based off a superset of 'python'.
     # To follow Sphinx's method of highlighting, use Confluence's 'python'


### PR DESCRIPTION
Fixes #150 

Signed-off-by: James Bungard <jmbungard@gmail.com>