### PR TITLE
builder: handle ref with no id in remove-title-check

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -299,14 +299,14 @@ class ConfluenceBuilder(Builder):
                 # generated title link.
                 if 'refid' in title_element:
                     for node in doctree.traverse(nodes.reference):
-                        if ('ids' in node
-                                and node['ids'][0] == title_element['refid']):
-                            def remove_until_has_children(node):
-                                parent = node.parent
-                                parent.remove(node)
-                                if not parent.children:
-                                    remove_until_has_children(parent)
-                            remove_until_has_children(node)
+                        if 'ids' in node and node['ids']:
+                            if node['ids'][0] == title_element['refid']:
+                                def remove_until_has_children(node):
+                                    parent = node.parent
+                                    parent.remove(node)
+                                    if not parent.children:
+                                        remove_until_has_children(parent)
+                                remove_until_has_children(node)
 
                 title_element.parent.remove(title_element)
 


### PR DESCRIPTION
When a configuration flags to remove the initial title from Confluence pages, additional work is performed to remove local references from those titles so that a local table of contents does not generate a bad link to itself. This check compares the references identifiers to the matching title's reference identifier before removing; however, not all references may have identifiers (not a requirement for docutils). Adjusting to ensure we check if any identifiers exist before pulling an identifier to check against.