### PR TITLE
re-enable contents unit test

### DIFF
--- a/test/unit-tests/common/expected/contents.conf
+++ b/test/unit-tests/common/expected/contents.conf
@@ -2,36 +2,36 @@
 <ul>
     <li>
         <p><ac:link ac:anchor="section1">
-            <ac:plain-text-link-body><![CDATA[section 1]]></ac:plain-text-link-body>
+            <ac:link-body>section 1</ac:link-body>
         </ac:link></p>
         <ul>
             <li>
                 <p><ac:link ac:anchor="section11">
-                    <ac:plain-text-link-body><![CDATA[section 1 1]]></ac:plain-text-link-body>
+                    <ac:link-body>section 1 1</ac:link-body>
                 </ac:link></p>
             </li>
         </ul>
     </li>
     <li>
         <p><ac:link ac:anchor="section2">
-            <ac:plain-text-link-body><![CDATA[section 2]]></ac:plain-text-link-body>
+            <ac:link-body>section 2</ac:link-body>
         </ac:link></p>
         <ul>
             <li>
                 <p><ac:link ac:anchor="section21">
-                    <ac:plain-text-link-body><![CDATA[section 2 1]]></ac:plain-text-link-body>
+                    <ac:link-body>section 2 1</ac:link-body>
                 </ac:link></p>
             </li>
             <li>
                 <p><ac:link ac:anchor="section22">
-                    <ac:plain-text-link-body><![CDATA[section 2 2]]></ac:plain-text-link-body>
+                    <ac:link-body>section 2 2</ac:link-body>
                 </ac:link></p>
             </li>
         </ul>
     </li>
     <li>
         <p><ac:link ac:anchor="section3">
-            <ac:plain-text-link-body><![CDATA[section 3]]></ac:plain-text-link-body>
+            <ac:link-body>section 3</ac:link-body>
         </ac:link></p>
     </li>
 </ul>

--- a/test/unit-tests/common/test_common.py
+++ b/test/unit-tests/common/test_common.py
@@ -43,7 +43,6 @@ class TestConfluenceCommon(unittest.TestCase):
         self._assertExpectedWithOutput('citations')
 
     def test_contents(self):
-        raise unittest.SkipTest('pending pull request #126')
         self._assertExpectedWithOutput('contents')
 
     def test_definition_lists(self):


### PR DESCRIPTION
Since this test was pending on pending pull request #126 and said request has been since pulled into the tree, re-enabling the test.