### PR TITLE
Explicitly define a subset of document names to publish

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -567,24 +567,6 @@ configuration).
 
    confluence_proxy = 'myawesomeproxy:8080'
 
-.. _confluence_timeout:
-
-confluence_timeout
-~~~~~~~~~~~~~~~~~~
-
-Force a timeout (in seconds) for network interaction. The timeout used by this
-extension is not explicitly configured (i.e. managed by Requests_ and other
-implementations). By default, assume that any network interaction will not
-timeout. Since the target Confluence instance is most likely to be found on an
-external server, is it recommended to explicitly configure a timeout value based
-on the environment being used. For example, to configure a timeout of ten
-seconds, the following can be used:
-
-.. code-block:: python
-
-   confluence_timeout = 10
-
-
 .. |confluence_publish_subset| replace:: ``confluence_publish_subset``
 .. _confluence_publish_subset:
 
@@ -629,6 +611,22 @@ and lines commented out with the *#* character.
 
 Disables |confluence_purge|_ setting when used.
 
+.. _confluence_timeout:
+
+confluence_timeout
+~~~~~~~~~~~~~~~~~~
+
+Force a timeout (in seconds) for network interaction. The timeout used by this
+extension is not explicitly configured (i.e. managed by Requests_ and other
+implementations). By default, assume that any network interaction will not
+timeout. Since the target Confluence instance is most likely to be found on an
+external server, is it recommended to explicitly configure a timeout value based
+on the environment being used. For example, to configure a timeout of ten
+seconds, the following can be used:
+
+.. code-block:: python
+
+   confluence_timeout = 10
 
 .. references ------------------------------------------------------------------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -584,6 +584,52 @@ seconds, the following can be used:
 
    confluence_timeout = 10
 
+
+.. |confluence_publish_subset| replace:: ``confluence_publish_subset``
+.. _confluence_publish_subset:
+
+confluence_publish_subset
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Control which documents to publish.
+Specify a collection of document names to filter publishing.
+
+.. note::
+
+    Document name is a relative file path **without** the file extension.
+
+When passing a list of documents to sphinx-build_,
+all dependencies of those documents get processed as well.
+If publishing such dependencies is undesirable,
+|confluence_publish_subset|_ enables skipping it.
+
+Subset of documents can be specified in the build command itself:
+
+.. code-block:: none
+
+    sphinx-build -b confluence \
+        -D confluence_publish_subset=index,foo/bar \
+        . _build/confluence index.rst foo/bar.rst
+
+The following code in ``conf.py`` would read the subset from a file
+where the path to the file is set as an environment variable.
+
+.. code-block:: python
+
+    subset_path = os.getenv('PUBLISH_SUBSET')
+    if subset_path and os.path.isfile(subset_path):
+        with open(subset_path) as f:
+            confluence_publish_subset = [line
+                                         for raw_line in f
+                                         for line in [raw_line.strip()]
+                                         if line and not line.startswith('#')]
+
+To ease maintenance, these files can contain blank lines
+and lines commented out with the *#* character.
+
+Disables |confluence_purge|_ setting when used.
+
+
 .. references ------------------------------------------------------------------
 
 .. _API tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
@@ -598,3 +644,4 @@ seconds, the following can be used:
 .. _master_doc: http://www.sphinx-doc.org/en/stable/config.html#confval-master_doc
 .. _toctree: http://www.sphinx-doc.org/en/stable/markup/toctree.html#directive-toctree
 .. _write_doc: http://www.sphinx-doc.org/en/stable/extdev/builderapi.html#sphinx.builders.Builder.write_doc
+.. _sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -567,49 +567,37 @@ configuration).
 
    confluence_proxy = 'myawesomeproxy:8080'
 
-.. |confluence_publish_subset| replace:: ``confluence_publish_subset``
 .. _confluence_publish_subset:
 
 confluence_publish_subset
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Control which documents to publish.
-Specify a collection of document names to filter publishing.
-
 .. note::
 
-    Document name is a relative file path **without** the file extension.
+    If ``confluence_publish_subset`` is configured, this option disables
+    |confluence_purge|_.
 
-When passing a list of documents to sphinx-build_,
-all dependencies of those documents get processed as well.
-If publishing such dependencies is undesirable,
-|confluence_publish_subset|_ enables skipping it.
-
-Subset of documents can be specified in the build command itself:
-
-.. code-block:: none
-
-    sphinx-build -b confluence \
-        -D confluence_publish_subset=index,foo/bar \
-        . _build/confluence index.rst foo/bar.rst
-
-The following code in ``conf.py`` would read the subset from a file
-where the path to the file is set as an environment variable.
+Provides the ability for a publisher to explicitly list a subset of documents to
+be published to a Confluence instance. When a user invokes sphinx-build_, a user
+has the ability to process all documents (by default) or specifying individual
+filenames which use the provide files and detected dependencies. If the
+Sphinx-detected set of documents to process contain undesired documents to
+publish, ``confluence_publish_subset`` can be used to override this. Defined
+document names should be a relative file path without the file extension. For
+example:
 
 .. code-block:: python
 
-    subset_path = os.getenv('PUBLISH_SUBSET')
-    if subset_path and os.path.isfile(subset_path):
-        with open(subset_path) as f:
-            confluence_publish_subset = [line
-                                         for raw_line in f
-                                         for line in [raw_line.strip()]
-                                         if line and not line.startswith('#')]
+   confluence_publish_subset = ['index', 'foo/bar']
 
-To ease maintenance, these files can contain blank lines
-and lines commented out with the *#* character.
+A user can force a publishing subset through the command line:
 
-Disables |confluence_purge|_ setting when used.
+.. code-block:: none
+
+   sphinx-build [options] -D confluence_publish_subset=index,foo/bar \
+       <srcdir> <outdir> index.rst foo/bar.rst
+
+By default, this option is ignored with a value of ``[]``.
 
 .. _confluence_timeout:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -597,7 +597,8 @@ A user can force a publishing subset through the command line:
    sphinx-build [options] -D confluence_publish_subset=index,foo/bar \
        <srcdir> <outdir> index.rst foo/bar.rst
 
-By default, this option is ignored with a value of ``[]``.
+By default, this option is ignored with a value of ``[]``. See also
+:ref:`manage publishing a document subset<tip_manage_publish_subset>`.
 
 .. _confluence_timeout:
 

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -99,7 +99,7 @@ subset publishing can be commonly used by setting the
 ``confluence_publish_subset`` option in a command line build, this may not be
 ideal for some environments. The following is a code snippet, which when
 included in a project's ``conf.py`` file, will provide a means for a user to
-specify a file outlining which documents are desire:
+specify a file outlining which documents are desired:
 
 .. code-block:: python
 

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -86,6 +86,35 @@ may not desire two failed attempts when publishing a documentation set. To
 disable attempts to publish using the XML-RPC API, see
 ``confluence_disable_xmlrpc`` (:ref:`jump<confluence_disable_xmlrpc>`).
 
+.. _tip_manage_publish_subset:
+
+manage publishing a document subset
+-----------------------------------
+
+Users have the ability to publish a subset of processed documents by using the
+``confluence_publish_subset`` (:ref:`jump<confluence_publish_subset>`) option.
+This can be useful for large documentation sets where a user may wish to only
+publish an update for one or more documents (instead of the entire set). While
+subset publishing can be commonly used by setting the
+``confluence_publish_subset`` option in a command line build, this may not be
+ideal for some environments. The following is a code snippet, which when
+included in a project's ``conf.py`` file, will provide a means for a user to
+specify a file outlining which documents are desire:
+
+.. code-block:: python
+
+    subset_path = os.getenv('PUBLISH_SUBSET')
+    if subset_path and os.path.isfile(subset_path):
+        with open(subset_path) as f:
+            confluence_publish_subset = [line
+                                         for raw_line in f
+                                         for line in [raw_line.strip()]
+                                         if line and not line.startswith('#')]
+
+Individual documents can be added into the file defined by the environment
+variable ``PUBLISH_SUBSET`` per line. In this snippet, blank lines and lines
+commented out with the ``#`` character are ignored.
+
 asking for help
 ---------------
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -86,6 +86,8 @@ def setup(app):
     app.add_config_value('confluence_link_transform', None, False)
     """Remove a detected title from generated documents."""
     app.add_config_value('confluence_remove_title', True, False)
+    """Process this subset of docnames."""
+    app.add_config_value('confluence_doc_subset', None, False)
 
     """(advanced-configuration - publishing)"""
     """Request for publish password to come from interactive session."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -114,7 +114,7 @@ def setup(app):
     """Timeout for network-related calls (publishing)."""
     app.add_config_value('confluence_timeout', None, False)
     """Subset of document names to publish"""
-    app.add_config_value('confluence_publish_subset', None, False)
+    app.add_config_value('confluence_publish_subset', [], False)
 
     """(advanced - undocumented)"""
     """Enablement for aggressive descendents search (for purge)."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -111,10 +111,10 @@ def setup(app):
     app.add_config_value('confluence_parent_page_id_check', None, False)
     """Proxy server needed to communicate with Confluence server."""
     app.add_config_value('confluence_proxy', None, False)
-    """Timeout for network-related calls (publishing)."""
-    app.add_config_value('confluence_timeout', None, False)
     """Subset of document names to publish"""
     app.add_config_value('confluence_publish_subset', [], False)
+    """Timeout for network-related calls (publishing)."""
+    app.add_config_value('confluence_timeout', None, False)
 
     """(advanced - undocumented)"""
     """Enablement for aggressive descendents search (for purge)."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -86,8 +86,6 @@ def setup(app):
     app.add_config_value('confluence_link_transform', None, False)
     """Remove a detected title from generated documents."""
     app.add_config_value('confluence_remove_title', True, False)
-    """Process this subset of docnames."""
-    app.add_config_value('confluence_doc_subset', None, False)
 
     """(advanced-configuration - publishing)"""
     """Request for publish password to come from interactive session."""
@@ -115,6 +113,8 @@ def setup(app):
     app.add_config_value('confluence_proxy', None, False)
     """Timeout for network-related calls (publishing)."""
     app.add_config_value('confluence_timeout', None, False)
+    """Subset of document names to publish"""
+    app.add_config_value('confluence_publish_subset', None, False)
 
     """(advanced - undocumented)"""
     """Enablement for aggressive descendents search (for purge)."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -136,8 +136,8 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
-        if self.config.confluence_doc_subset is not None:
-            self.doc_subset = set(self.config.confluence_doc_subset)
+        if self.config.confluence_publish_subset is not None:
+            self.doc_subset = set(self.config.confluence_publish_subset)
         else:
             self.doc_subset = None
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -414,7 +414,12 @@ class ConfluenceBuilder(Builder):
                 ConfluenceLogger.info('done\n')
 
     def publish_purge(self):
-        if self.config.confluence_purge and self.doc_subset is None:
+        if self.config.confluence_purge:
+            if self.doc_subset:
+                ConfluenceLogger.warn('confluence_purge disabled due to '
+                                      'confluence_publish_subset')
+                return
+
             if self.legacy_pages:
                 n = len(self.legacy_pages)
                 ConfluenceLogger.info(

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -70,7 +70,8 @@ class ConfluenceBuilder(Builder):
         ConfluenceState.reset()
 
     def init(self, suppress_conf_check=False):
-        if not ConfluenceConfig.validate(self.config, not suppress_conf_check):
+        if not ConfluenceConfig.validate(self.config, self.env,
+                                         not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 
         if self.config.confluence_ask_password:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -135,7 +135,7 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
-        if self.config.confluence_publish_subset is not None:
+        if self.config.confluence_publish_subset:
             self.doc_subset = set(self.config.confluence_publish_subset)
         else:
             self.doc_subset = None

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -70,8 +70,7 @@ class ConfluenceBuilder(Builder):
         ConfluenceState.reset()
 
     def init(self, suppress_conf_check=False):
-        if not ConfluenceConfig.validate(self.config, self.env,
-                                         not suppress_conf_check):
+        if not ConfluenceConfig.validate(self, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 
         if self.config.confluence_ask_password:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -248,9 +248,7 @@ class ConfluenceBuilder(Builder):
     def process_tree_structure(self, ordered, docname, traversed, depth=0):
         omit = False
         max_depth = self.config.confluence_max_doc_depth
-        too_deep = max_depth is not None and depth > max_depth
-        skip = self.doc_subset and docname not in self.doc_subset
-        if too_deep or skip:
+        if max_depth is not None and depth > max_depth:
             omit = True
             self.omitted_docnames.append(docname)
 
@@ -451,6 +449,8 @@ class ConfluenceBuilder(Builder):
                     self.publish_docnames, 'publishing documents... ',
                     length=len(self.publish_docnames),
                     verbosity=self.app.verbosity):
+                if self.doc_subset and docname not in self.doc_subset:
+                    continue
                 docfile = path.join(self.outdir, self.file_transform(docname))
 
                 try:
@@ -470,6 +470,8 @@ class ConfluenceBuilder(Builder):
                     length=len(assets), verbosity=self.app.verbosity,
                     stringify_func=to_asset_name):
                 key, absfile, type, hash, docname = asset
+                if self.doc_subset and docname not in self.doc_subset:
+                    continue
 
                 try:
                     with open(absfile, 'rb') as file:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -136,6 +136,11 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
+        if self.config.confluence_doc_subset is not None:
+            self.doc_subset = set(self.config.confluence_doc_subset)
+        else:
+            self.doc_subset = None
+
     def get_outdated_docs(self):
         """
         Return an iterable of input files that are outdated.
@@ -244,7 +249,9 @@ class ConfluenceBuilder(Builder):
     def process_tree_structure(self, ordered, docname, traversed, depth=0):
         omit = False
         max_depth = self.config.confluence_max_doc_depth
-        if max_depth is not None and depth > max_depth:
+        too_deep = max_depth is not None and depth > max_depth
+        skip = self.doc_subset and docname not in self.doc_subset
+        if too_deep or skip:
             omit = True
             self.omitted_docnames.append(docname)
 
@@ -410,7 +417,7 @@ class ConfluenceBuilder(Builder):
                 ConfluenceLogger.info('done\n')
 
     def publish_purge(self):
-        if self.config.confluence_purge:
+        if self.config.confluence_purge and self.doc_subset is None:
             if self.legacy_pages:
                 n = len(self.legacy_pages)
                 ConfluenceLogger.info(

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -136,9 +136,9 @@ class ConfluenceBuilder(Builder):
             self.space_name = None
 
         if self.config.confluence_publish_subset:
-            self.doc_subset = set(self.config.confluence_publish_subset)
+            self.publish_subset = set(self.config.confluence_publish_subset)
         else:
-            self.doc_subset = None
+            self.publish_subset = None
 
     def get_outdated_docs(self):
         """
@@ -415,7 +415,7 @@ class ConfluenceBuilder(Builder):
 
     def publish_purge(self):
         if self.config.confluence_purge:
-            if self.doc_subset:
+            if self.publish_subset:
                 ConfluenceLogger.warn('confluence_purge disabled due to '
                                       'confluence_publish_subset')
                 return
@@ -454,7 +454,7 @@ class ConfluenceBuilder(Builder):
                     self.publish_docnames, 'publishing documents... ',
                     length=len(self.publish_docnames),
                     verbosity=self.app.verbosity):
-                if self.doc_subset and docname not in self.doc_subset:
+                if self.publish_subset and docname not in self.publish_subset:
                     continue
                 docfile = path.join(self.outdir, self.file_transform(docname))
 
@@ -475,7 +475,7 @@ class ConfluenceBuilder(Builder):
                     length=len(assets), verbosity=self.app.verbosity,
                     stringify_func=to_asset_name):
                 key, absfile, type, hash, docname = asset
-                if self.doc_subset and docname not in self.doc_subset:
+                if self.publish_subset and docname not in self.publish_subset:
                     continue
 
                 try:

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -18,7 +18,7 @@ class ConfluenceConfig:
     """
 
     @staticmethod
-    def validate(c, env, log=True):
+    def validate(builder, log=True):
         """
         validate a provided configuration
 
@@ -27,6 +27,7 @@ class ConfluenceConfig:
         while returning False for a known bad configuration.
         """
         errState = False
+        c = builder.config
 
         if c.confluence_footer_file:
             if not os.path.isfile(c.confluence_footer_file):
@@ -73,7 +74,7 @@ string, etc.).
 """'confluence_publish_subset' should be a collection of strings""")
             else:
                 for docname in c.confluence_doc_subset:
-                    if not any(os.path.isfile(os.path.join(env.srcdir,
+                    if not any(os.path.isfile(os.path.join(builder.env.srcdir,
                                                            docname + suffix))
                                for suffix in c.source_suffix):
                         errState = True

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -64,11 +64,13 @@ string, etc.).
 """)
 
         if c.confluence_publish_subset:
-            if not isinstance(c.confluence_publish_subset, (tuple, list)):
+            if not (isinstance(c.confluence_publish_subset, (tuple, list, set))
+                    and all(isinstance(docname, str)
+                            for docname in c.confluence_publish_subset)):
                 errState = True
                 if log:
                     ConfluenceLogger.error(
-"""'confluence_publish_subset' should be a tuple or a list""")
+"""'confluence_publish_subset' should be a collection of strings""")
             else:
                 for docname in c.confluence_doc_subset:
                     if not any(os.path.isfile(os.path.join(env.srcdir,

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -73,7 +73,7 @@ string, etc.).
                     ConfluenceLogger.error(
 """'confluence_publish_subset' should be a collection of strings""")
             else:
-                for docname in c.confluence_doc_subset:
+                for docname in c.confluence_publish_subset:
                     if not any(os.path.isfile(os.path.join(builder.env.srcdir,
                                                            docname + suffix))
                                for suffix in c.source_suffix):

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -63,12 +63,12 @@ defined maximum document depth must be defined as an integer value (not a float,
 string, etc.).
 """)
 
-        if c.confluence_doc_subset:
-            if not isinstance(c.confluence_doc_subset, (tuple, list)):
+        if c.confluence_publish_subset:
+            if not isinstance(c.confluence_publish_subset, (tuple, list)):
                 errState = True
                 if log:
                     ConfluenceLogger.error(
-"""'confluence_doc_subset' should be a tuple or a list""")
+"""'confluence_publish_subset' should be a tuple or a list""")
             else:
                 for docname in c.confluence_doc_subset:
                     if not any(os.path.isfile(os.path.join(env.srcdir,
@@ -77,7 +77,7 @@ string, etc.).
                         errState = True
                         if log:
                             ConfluenceLogger.error(
-"""Document '%s' in 'confluence_doc_subset' not found""", docname)
+"""Document '%s' in 'confluence_publish_subset' not found""", docname)
 
         if c.confluence_publish:
             if c.confluence_disable_rest and c.confluence_disable_xmlrpc:

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -7,6 +7,7 @@
 from .logger import ConfluenceLogger
 import os.path
 
+
 class ConfluenceConfig:
     """
     confluence configuration validation utility class
@@ -17,7 +18,7 @@ class ConfluenceConfig:
     """
 
     @staticmethod
-    def validate(c, log=True):
+    def validate(c, env, log=True):
         """
         validate a provided configuration
 
@@ -61,6 +62,22 @@ When limiting the document depth permitted for a building/publishing event, the
 defined maximum document depth must be defined as an integer value (not a float,
 string, etc.).
 """)
+
+        if c.confluence_doc_subset:
+            if not isinstance(c.confluence_doc_subset, (tuple, list)):
+                errState = True
+                if log:
+                    ConfluenceLogger.error(
+"""'confluence_doc_subset' should be a tuple or a list""")
+            else:
+                for docname in c.confluence_doc_subset:
+                    if not any(os.path.isfile(os.path.join(env.srcdir,
+                                                           docname + suffix))
+                               for suffix in c.source_suffix):
+                        errState = True
+                        if log:
+                            ConfluenceLogger.error(
+"""Document '%s' in 'confluence_doc_subset' not found""", docname)
 
         if c.confluence_publish:
             if c.confluence_disable_rest and c.confluence_disable_xmlrpc:


### PR DESCRIPTION
If subset of document names is defined using the `confluence_doc_subset` option, only those documents are processed and uploaded.

This is especially useful for large projects with demanding plugins for building pages (like `sphinxcontrib-plantuml` for example). When starting a build from scratch or when publishing every page is not desired, it is good to be able to explicitly control what will be done.

Using this options implicitly disables `confluence_purge` as keeping it enabled would delete every document that is not in the subset.