### PR TITLE
Use Sphinx Builder.create_translator() to create translator in writer.

### DIFF
--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -5,9 +5,9 @@
 """
 
 from __future__ import (absolute_import, print_function, unicode_literals)
-from .logger import ConfluenceLogger
-from .translator import ConfluenceTranslator
+
 from docutils import writers
+
 
 class ConfluenceWriter(writers.Writer):
     supported = ('text',)
@@ -20,7 +20,7 @@ class ConfluenceWriter(writers.Writer):
         self.output = None
 
     def translate(self):
-        visitor = ConfluenceTranslator(self.document, self.builder)
+        visitor = self.builder.create_translator(self.document, self.builder)
         self.document.walkabout(visitor)
         if hasattr(visitor, 'document'):
             self.output = visitor.document


### PR DESCRIPTION
Enables other extensions to use `sphinx.application.Sphinx#add_node`
to support additional node types for confluence output.

Complements changes related to tonybaloney/sphinxcontrib-confluencebuilder#165

Signed-off-by: Pawel Limanowka <plimanowka@gmail.com>