### PR TITLE
Support Sphinx's parallel mode (the `-j` option to `sphinx-build`)

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -125,3 +125,9 @@ def setup(app):
     app.add_config_value('confluence_adv_trace_data', False, False)
     """Do not cap sections to a maximum of six (6) levels."""
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -52,9 +52,9 @@ def relative_uri(base, to):
 
 
 class ConfluenceBuilder(Builder):
+    allow_parallel = True
     name = 'confluence'
     format = 'confluence'
-    allow_parallel = True
 
     def __init__(self, app):
         super(ConfluenceBuilder, self).__init__(app)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -60,7 +60,6 @@ class ConfluenceBuilder(Builder):
         super(ConfluenceBuilder, self).__init__(app)
 
         self.cache_doctrees = {}
-        self.current_docname = None
         self.file_suffix = '.conf'
         self.link_suffix = None
         self.master_doc_page_id = None
@@ -289,7 +288,6 @@ class ConfluenceBuilder(Builder):
     def write_doc(self, docname, doctree):
         if docname in self.omitted_docnames:
             return
-        self.current_docname = docname
 
         # remove title from page contents (if any)
         if self.config.confluence_remove_title:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -24,6 +24,7 @@ from sphinx.util.osutil import ensuredir, SEP
 import io
 import sys
 
+
 # Clone of relative_uri() sphinx.util.osutil, with bug-fixes
 # since the original code had a few errors.
 # This was fixed in Sphinx 1.2b.
@@ -49,9 +50,11 @@ def relative_uri(base, to):
         return '.' + SEP
     return ('..' + SEP) * (len(b2)-1) + SEP.join(t2)
 
+
 class ConfluenceBuilder(Builder):
     name = 'confluence'
     format = 'confluence'
+    allow_parallel = True
 
     def __init__(self, app):
         super(ConfluenceBuilder, self).__init__(app)

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -41,8 +41,8 @@ class ConfluenceTranslator(BaseTranslator):
         config = builder.config
 
         # acquire the active document name from the builder
-        assert builder.current_docname
-        self.docname = builder.current_docname
+        assert 'source' in document
+        self.docname = self.builder.env.path2doc(document['source'])
 
         # determine the active document's parent path to assist it title mapping
         # for relative document uris


### PR DESCRIPTION
Without these changes `sphinx-build` refuses to work in parallel.

In my projects, using the `-j` option with these changes did not produce any ill effects. Is there a reason it shouldn't be allowed?