### PR TITLE
Only publish documents that Sphinx asked to prepare

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -206,7 +206,9 @@ class ConfluenceBuilder(Builder):
 
             doctitle = ConfluenceState.registerTitle(docname, doctitle,
                 self.config.confluence_publish_prefix)
-            self.publish_docnames.append(docname)
+            if docname in docnames:
+                # Only publish documents that Sphinx asked to prepare
+                self.publish_docnames.append(docname)
 
             toctrees = doctree.traverse(addnodes.toctree)
             if toctrees and toctrees[0].get('maxdepth') > 0:


### PR DESCRIPTION
When specifying individual files to build to `sphinx-build`, `ConfluenceBuilder` ignores this document subset and publishes everything.

This change makes publishing work as expected for my use case and unit tests pass, but please examine the change to see if it potentially introduces any issues. Is it correct to assume that the `docnames` argument to `ConfluenceBuilder.prepare_writing` will always contain everything that needs to be published; or could  `process_tree_structure` in some case produce a document that must be uploaded but is not present in the `docnames` argument?