### PR TITLE
test: validate publish subset options

### DIFF
--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -28,6 +28,7 @@ class ConfluenceConfig:
         """
         errState = False
         c = builder.config
+        env = builder.app.env
 
         if c.confluence_footer_file:
             if not os.path.isfile(c.confluence_footer_file):
@@ -74,7 +75,7 @@ string, etc.).
 """'confluence_publish_subset' should be a collection of strings""")
             else:
                 for docname in c.confluence_publish_subset:
-                    if not any(os.path.isfile(os.path.join(builder.env.srcdir,
+                    if not any(os.path.isfile(os.path.join(env.srcdir,
                                                            docname + suffix))
                                for suffix in c.source_suffix):
                         errState = True


### PR DESCRIPTION
Adding a series of unit test assertions to validate the recently added `confluence_publish_subset` option.

Note that this test introduces the use of a `_build_app` helper application, to ensure there is no configuration conflict between individual unit tests. Ideally, other tests can be updated in the future to prevent additional conflicts.