### PR TITLE
test: wrap docutils namespace for sphinx invokes

### DIFF
--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2018-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -72,8 +72,7 @@ class TestConfluenceValidation(unittest.TestCase):
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-base')
 
         # build/publish test base page
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, cls.config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, cls.config)
 
         # finalize configuration for tests
         cls.config['confluence_master_homepage'] = False
@@ -91,8 +90,7 @@ class TestConfluenceValidation(unittest.TestCase):
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-autodocs')
         sys.path.insert(0, os.path.join(dataset, 'src'))
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
         sys.path.pop(0)
 
@@ -102,8 +100,7 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'common')
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-common')
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
     def test_common_macro_restricted(self):
         config = dict(self.config)
@@ -121,8 +118,7 @@ class TestConfluenceValidation(unittest.TestCase):
         config['confluence_header_file'] = os.path.join(dataset, 'no-macro.tpl')
         config['confluence_publish_prefix'] += 'nomacro-'
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
     def test_header_footer(self):
         config = dict(self.config)
@@ -133,8 +129,7 @@ class TestConfluenceValidation(unittest.TestCase):
         config['confluence_header_file'] = os.path.join(dataset, 'header.tpl')
         config['confluence_footer_file'] = os.path.join(dataset, 'footer.tpl')
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
     def test_hierarchy(self):
         config = dict(self.config)
@@ -144,8 +139,7 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'hierarchy')
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-hierarchy')
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
     def test_xmlrpc(self):
         config = dict(self.config)
@@ -155,8 +149,7 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'xmlrpc')
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-xmlrpc')
 
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
 if __name__ == '__main__':
     sys.exit(unittest.main(verbosity=0))

--- a/test/unit-tests/common/test_common.py
+++ b/test/unit-tests/common/test_common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -18,11 +18,16 @@ class TestConfluenceCommon(unittest.TestCase):
         self.expected = os.path.join(test_dir, 'expected')
 
         doc_dir, doctree_dir = _.prepareDirectories('common')
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
-
         self.doc_dir = doc_dir
-        self.app = app
+
+        with _.prepareSphinx(dataset, doc_dir, doctree_dir, self.config) as app:
+            app.build(force_all=True)
+
+            # track registered extensions
+            if hasattr(app, 'extensions'):
+                self.extensions = list(app.extensions.keys())
+            else:
+                self.extensions = list(app._extensions.keys())
 
     def _assertExpectedWithOutput(self, name):
         _.assertExpectedWithOutput(self, name, self.expected, self.doc_dir)
@@ -97,10 +102,7 @@ class TestConfluenceCommon(unittest.TestCase):
 
     def test_registry(self):
         # validate builder's registration into Sphinx
-        if hasattr(self.app, 'extensions'):
-            self.assertTrue(EXT_NAME in self.app.extensions.keys())
-        else:
-            self.assertTrue(EXT_NAME in self.app._extensions.keys())
+        self.assertTrue(EXT_NAME in self.extensions)
 
     def test_sections(self):
         self._assertExpectedWithOutput('sections')

--- a/test/unit-tests/common/test_header_footer.py
+++ b/test/unit-tests/common/test_header_footer.py
@@ -28,10 +28,11 @@ class TestConfluenceHeaderFooter(unittest.TestCase):
         config['confluence_header_file'] = header_tpl
 
         doc_dir, doctree_dir = _.prepareDirectories('header-footer')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
-        _.assertExpectedWithOutput(
-            self, 'header-footer', self.expected, doc_dir, tpn='header-footer')
+        
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            _.assertExpectedWithOutput(self, 'header-footer', self.expected,
+                doc_dir, tpn='header-footer')
 
     def test_headerfooter_relative(self):
         config = dict(self.config)
@@ -39,7 +40,7 @@ class TestConfluenceHeaderFooter(unittest.TestCase):
         config['confluence_header_file'] = '../templates/sample-header.tpl'
 
         doc_dir, doctree_dir = _.prepareDirectories('header-footer')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
-        _.assertExpectedWithOutput(
-            self, 'header-footer', self.expected, doc_dir, tpn='header-footer')
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            _.assertExpectedWithOutput(self, 'header-footer', self.expected,
+                doc_dir, tpn='header-footer')

--- a/test/unit-tests/common/test_headings.py
+++ b/test/unit-tests/common/test_headings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -9,8 +9,6 @@ from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
 import os
 import unittest
-
-from pkg_resources import iter_entry_points
 
 class TestConfluenceCommonHeadings(unittest.TestCase):
     @classmethod
@@ -23,8 +21,7 @@ class TestConfluenceCommonHeadings(unittest.TestCase):
 
     def test_headings_default(self):
         doc_dir, doctree_dir = _.prepareDirectories('headings-default')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
         _.assertExpectedWithOutput(
             self, 'headings-default', self.expected, doc_dir, tpn='headings')
 
@@ -33,7 +30,6 @@ class TestConfluenceCommonHeadings(unittest.TestCase):
         config['confluence_remove_title'] = False
 
         doc_dir, doctree_dir = _.prepareDirectories('headings-with-title')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
         _.assertExpectedWithOutput(
             self, 'headings-with-title', self.expected, doc_dir, tpn='headings')

--- a/test/unit-tests/common/test_manpage.py
+++ b/test/unit-tests/common/test_manpage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2018-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -30,14 +30,12 @@ class TestConfluenceManpage(unittest.TestCase):
         config['manpages_url'] = 'https://manpages.example.com/{path}'
 
         doc_dir, doctree_dir = _.prepareDirectories('manpage-conf')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
         _.assertExpectedWithOutput(
             self, 'manpage-conf', self.expected, doc_dir, tpn='contents')
 
     def test_manpage_without_config(self):
         doc_dir, doctree_dir = _.prepareDirectories('manpage-noconf')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
         _.assertExpectedWithOutput(
             self, 'manpage-noconf', self.expected, doc_dir, tpn='contents')

--- a/test/unit-tests/literal-markup/test_literal_markup.py
+++ b/test/unit-tests/literal-markup/test_literal_markup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2016-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -19,8 +19,7 @@ class TestConfluenceLiteralMarkup(unittest.TestCase):
         self.expected = os.path.join(test_dir, 'expected')
 
         doc_dir, doctree_dir = _.prepareDirectories('literal-markup')
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, self.config)
 
         self.doc_dir = doc_dir
 

--- a/test/unit-tests/literal-markup/test_literal_markup_advanced.py
+++ b/test/unit-tests/literal-markup/test_literal_markup_advanced.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2018-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -21,8 +21,7 @@ class TestConfluenceLiteralMarkupAdvanced(unittest.TestCase):
     def test_highlights_default(self):
         expected = os.path.join(self.test_dir, 'expected-hd')
         doc_dir, doctree_dir = _.prepareDirectories('literal-markup-hd')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
+        _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
         _.assertExpectedWithOutput(self, 'contents', expected, doc_dir)
 
     def test_highlights_set(self):
@@ -31,8 +30,7 @@ class TestConfluenceLiteralMarkupAdvanced(unittest.TestCase):
 
         expected = os.path.join(self.test_dir, 'expected-hs')
         doc_dir, doctree_dir = _.prepareDirectories('literal-markup-hs')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
         _.assertExpectedWithOutput(self, 'contents', expected, doc_dir)
 
     def test_override_lang(self):
@@ -41,6 +39,5 @@ class TestConfluenceLiteralMarkupAdvanced(unittest.TestCase):
 
         expected = os.path.join(self.test_dir, 'expected-ol')
         doc_dir, doctree_dir = _.prepareDirectories('literal-markup-ol')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
         _.assertExpectedWithOutput(self, 'contents', expected, doc_dir)

--- a/test/unit-tests/toctree/test_toctree.py
+++ b/test/unit-tests/toctree/test_toctree.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2017-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -22,8 +22,7 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
 
         expected = os.path.join(self.test_dir, 'expected-cm')
         doc_dir, doctree_dir = _.prepareDirectories('toctree-markup-cm')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
+        _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
 
         _.assertExpectedWithOutput(self, 'contents', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'doca', expected, doc_dir)
@@ -33,8 +32,7 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
     def test_toctree_default(self):
         expected = os.path.join(self.test_dir, 'expected-def')
         doc_dir, doctree_dir = _.prepareDirectories('toctree-markup-def')
-        app = _.prepareSphinx(self.dataset, doc_dir, doctree_dir, self.config)
-        app.build(force_all=True)
+        _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
 
         _.assertExpectedWithOutput(self, 'contents', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'doca', expected, doc_dir)

--- a/test/unit-tests/toctree/test_toctree_hierarchy.py
+++ b/test/unit-tests/toctree/test_toctree_hierarchy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2018 by the contributors (see AUTHORS file).
+    :copyright: Copyright 2017-2019 by the contributors (see AUTHORS file).
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
@@ -22,11 +22,9 @@ class TestConfluenceToctreeHierarchyMarkup(unittest.TestCase):
         self.expected = os.path.join(test_dir, 'expected-hierarchy')
 
         doc_dir, doctree_dir = _.prepareDirectories('toctree-hierarchy')
-        app = _.prepareSphinx(dataset, doc_dir, doctree_dir, config)
-        app.build(force_all=True)
-
         self.doc_dir = doc_dir
-        self.app = app
+
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
     def test_max_depth(self):
         _.assertExpectedWithOutput(


### PR DESCRIPTION
For the series of unit and validations tests performed with multiple Sphinx instances, it is important to wrap the use of the Sphinx application around the docutils namespace. This prevents collisions for registers directives, etc. between the various Sphinx instances.

This change corrects a series of observed test warnings generated on execution. For example:

```
WARNING: while setting up extension sphinx.domains.changeset: directive 'deprecated' is already registered, it will be overridden
WARNING: while setting up extension sphinx.domains.changeset: directive 'versionadded' is already registered, it will be overridden
WARNING: while setting up extension sphinx.domains.changeset: directive 'versionchanged' is already registered, it will be overridden
WARNING: while setting up extension sphinx.domains.math: role 'eq' is already registered, it will be overridden
```