### PR TITLE
test: skip code block test in sphinx 1.8+ (interim)

### DIFF
--- a/test/unit-tests/literal-markup/test_literal_markup.py
+++ b/test/unit-tests/literal-markup/test_literal_markup.py
@@ -4,7 +4,9 @@
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
+from pkg_resources import parse_version
 from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+from sphinx.__init__ import __version__ as sphinx_version
 import os
 import unittest
 
@@ -23,7 +25,13 @@ class TestConfluenceLiteralMarkup(unittest.TestCase):
         self.doc_dir = doc_dir
 
     def test_code_blocks(self):
-        raise unittest.SkipTest('see issue #148')
+        # skip code-block tests in Sphinx v1.8.x+ due to regression; when a new
+        # stable version is released, this can be re-enabled for the newer
+        # version and greater
+        #
+        # https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/148
+        if parse_version(sphinx_version) > parse_version('1.7'):
+            raise unittest.SkipTest('not supported in sphinx-1.8.x+')
         _.assertExpectedWithOutput(
             self, 'code_blocks', self.expected, self.doc_dir)
 


### PR DESCRIPTION
Due to a regression in Sphinx 1.8, `linenothreshold` feature would not work as expected causing the code block test to fail \[1\]. To continue testing with older versions of Sphinx, enable the tests for pre-v1.8 environments. When the fix for `linenothreshold` has been introduced in a stable version of Sphinx, this test can be tweaks to support running on the respective newer versions.

\[1\]: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/148