### PR TITLE
test: skip manpages_url test in pre-sphinx 1.7

### DIFF
--- a/test/unit-tests/common/test_manpage.py
+++ b/test/unit-tests/common/test_manpage.py
@@ -4,13 +4,21 @@
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
+from pkg_resources import parse_version
 from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+from sphinx.__init__ import __version__ as sphinx_version
 import os
 import unittest
 
 class TestConfluenceManpage(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        # skip manpages_url tests if not using Sphinx v1.7+
+        #
+        # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-manpages_url
+        if parse_version(sphinx_version) < parse_version('1.7'):
+            raise unittest.SkipTest('manpages_url not supported pre-sphinx-1.7')
+
         test_dir = os.path.dirname(os.path.realpath(__file__))
 
         self.config = _.prepareConfiguration()


### PR DESCRIPTION
Sphinx's `manpages_url` feature has only been made available in Sphinx v1.7+ releases. Adjusting unit testing to skip over the manpages_url's specific tests when testing under an older version of Sphinx.