### PR TITLE
builder: cleanup output logging

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -243,9 +243,7 @@ class ConfluenceBuilder(Builder):
         # transformation stage (e.x. embedded images are converted into real
         # images in Sphinx, which is then provided to a translator). Embedded
         # images are detected during an 'doctree-resolved' hook (see __init__).
-        ConfluenceLogger.info('scanning for assets... ', nonl=0)
         self.assets.process(ordered_docnames)
-        ConfluenceLogger.info('done\n')
 
         ConfluenceState.titleConflictCheck()
 
@@ -356,7 +354,7 @@ class ConfluenceBuilder(Builder):
                 baseid = self.master_doc_page_id
             else:
                 baseid = self.parent_id
-            ConfluenceLogger.info('querying list of existing pages...')
+
             if self.config.confluence_adv_aggressive_search is True:
                 self.legacy_pages = self.publisher.getDescendantsCompat(baseid)
             else:


### PR DESCRIPTION
A series of informative logs added to the build process undesirable adjust the nice output generated by Sphinx. For example, 'querying list of existing pages' is injected into the output stream while publishing a documentation set. Below shows undesired logging to the user:
```
    pickling environment... done
    checking consistency... done
 >  preparing documents... scanning for assets...
 >  done
 >
 >  done
    writing output... [100%] verification-of-content
 >  querying list of existing pages...tents
    publishing documents... [100%] verification-of-content
    publishing assets... [100%] extern_....png
    build succeeded.
```
Instead, removing these extra logs for a cleaner output.