### PR TITLE
publisher: handle asset publishing with older requests

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -461,7 +461,8 @@ class ConfluencePublisher():
                 }
 
                 if not self.notify:
-                    data['minorEdit'] = True
+                    # using str over bool to support requests pre-v2.19.0
+                    data['minorEdit'] = 'true'
 
                 if not attachment:
                     url = 'content/{}/child/attachment'.format(page_id)


### PR DESCRIPTION
Confluence's API can accept attachment comments and the `minorEdit` argument through a set of uploaded files [1]. While in the most recent version of requests this is not an issue, requests pre-v2.19 has issues. The `minorEdit` value is provided in boolean form, which the older versions of requests does not handle well. Since this extension still attempts to support at least requests v2.14.0, a workaround is being applied. Instead of configuring the flag with a boolean value, set the value in a compatible string form.

\[1\]: https://docs.atlassian.com/atlassian-confluence/REST/6.6.0/#content/{id}/child/attachment-createAttachments
\[2\]: https://github.com/kennethreitz/requests/commit/8546a15587b2a240c1d1404d3ef99365b911bf13