### PR TITLE
setup.py: configure minimum versions in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ with open('README.rst', 'r') as readme_rst:
     long_desc = readme_rst.read()
 
 requires = [
-    'future',
-    'requests',
-    'Sphinx>=1.0',
+    'future>=0.16.0',
+    'requests>=2.14.0',
+    'sphinx>=1.6.3',
     ]
 
 setup(


### PR DESCRIPTION
The minimum supported versions of dependencies has been maintained inside the tox requirements definition (`requirements_dev.txt`). However, these versions were never explicitly set inside `setup.py`; correcting.