### PR TITLE
extend test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,39 @@ language: python
 matrix:
   include:
   - python: "2.7"
-    env: TOXENV=py27
+    env: TOXENV=py27-sphinx16
+  - python: "2.7"
+    env: TOXENV=py27-sphinx17
+  - python: "2.7"
+    env: TOXENV=py27-sphinx18
   - python: "3.4"
-    env: TOXENV=py34
+    env: TOXENV=py34-sphinx16
+  - python: "3.4"
+    env: TOXENV=py34-sphinx17
+  - python: "3.4"
+    env: TOXENV=py34-sphinx18
   - python: "3.5"
-    env: TOXENV=py35
+    env: TOXENV=py35-sphinx16
+  - python: "3.5"
+    env: TOXENV=py35-sphinx17
+  - python: "3.5"
+    env: TOXENV=py35-sphinx18
   - python: "3.6"
-    env: TOXENV=py36
+    env: TOXENV=py36-sphinx16
+  - python: "3.6"
+    env: TOXENV=py36-sphinx17
+  - python: "3.6"
+    env: TOXENV=py36-sphinx18
   - python: "3.7"
-    env: TOXENV=py37
+    env: TOXENV=py37-sphinx16
+    dist: xenial
+    sudo: true
+  - python: "3.7"
+    env: TOXENV=py37-sphinx17
+    dist: xenial
+    sudo: true
+  - python: "3.7"
+    env: TOXENV=py37-sphinx18
     dist: xenial
     sudo: true
   - python: "3.6"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,2 @@
 future>=0.16.0
 requests>=2.14.0
-sphinx>=1.6.3

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -58,7 +58,7 @@ class ConfluenceTranslator(BaseTranslator):
         self.nl = '\n'
         self.warn = document.reporter.warning
         self._building_footnotes = False
-        self._manpage_url = config.manpages_url
+        self._manpage_url = getattr(config, 'manpages_url', None)
         self._quote_level = 0
         self._reference_context = []
         self._section_level = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py{27,34,35,36}, lint, pylint
+envlist = py{27,34,35,36,37}-sphinx{16,17,18}, lint, pylint
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt
+        sphinx16: sphinx==1.6.3
+        sphinx17: sphinx>=1.7,<1.8
+        sphinx18: sphinx>=1.8
 changedir=test
 commands =
     python -m test_main {posargs}


### PR DESCRIPTION
Improving testing of this extension by including Python 3.7 and various Sphinx versions (1.6-1.8). Both the tox configuration and Travis CI configuration has been updated to test these new environments.